### PR TITLE
Initial Flask support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ uninstrument(django=False)  # removes previous instrumentation
 ## Supported Frameworks and Libraries
 
 * [Django](./signalfx_tracing/libraries/django_/README.md) - `instrument(django=True)`
+* [Flask](./signalfx_tracing/libraries/flask_/README.md) - `instrument(flask=True)`
 * [Tornado](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 https://github.com/rmfitzpatrick/python-django/tarball/django_2#egg=django-opentracing
 tornado_opentracing
+flask_opentracing
 opentracing
 wrapt

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 
 instrumented_attr = '__sfx_instrumented'
-traceable_libraries = ('django', 'tornado')
-auto_instrumentable_libraries = ('tornado',)
+traceable_libraries = ('django', 'flask', 'tornado')
+auto_instrumentable_libraries = ('flask', 'tornado')

--- a/signalfx_tracing/libraries/__init__.py
+++ b/signalfx_tracing/libraries/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 from .django_ import config as django_config  # noqa
+from .flask_ import config as flask_config  # noqa
 from .tornado_ import config as tornado_config  # noqa

--- a/signalfx_tracing/libraries/flask_/README.md
+++ b/signalfx_tracing/libraries/flask_/README.md
@@ -1,0 +1,76 @@
+# Flask
+
+- [opentracing-contrib/python-flask](https://github.com/opentracing-contrib/python-flask)
+- [Official Site](http://flask.pocoo.org)
+
+The SignalFx Auto-instrumenter configures the OpenTracing Project's Flask instrumentation for your Flask 0.10+
+applications.  You can enable instrumentation within your app and `Blueprint` routes by invoking the
+`signalfx_tracing.auto_instrument()` function before initializing your `Flask` application object.
+To configure tracing, some tunables are provided via `flask_config` to establish the desired tracer and
+request attributes for span tagging:
+
+| Setting name | Definition | Default value |
+| -------------|------------|---------------|
+| trace_all | Whether to trace all requests. | `True` |
+| traced_attributes | [Request attributes](http://flask.pocoo.org/docs/1.0/api/#flask.Request) to use as span tags. | `['path', 'method']` |
+| tracer | An instance of an OpenTracing-compatible tracer for all Tornado traces. | `opentracing.tracer` |
+
+```python
+# my_app.py
+from signalfx_tracing import auto_instrument, instrument
+from signalfx_tracing.libraries import flask_config
+
+import flask
+
+# ***
+# The SignalFx Flask Auto-instrumenter works by monkey patching the Flask.__init__() method.
+# You must invoke auto_instrument() or instrument() before instantiating your app and
+# decorating its routes:
+#
+# from sfx_tracing import instrument
+# instrument(flask=True)  # or sfx_tracing.auto_instrument()
+# instrumented_app = flask.Flask(...)
+#
+# Accessing Flask from its parent flask module object requires no advanced instrumentation
+# beyond that of pre-initialization.  If you are importing Flask from flask directly, you
+# must instrument before doing so:
+#
+# from sfx_tracing import instrument
+# instrument(flask=True)  # or sfx_tracing.auto_instrument()
+#
+# from flask import Flask
+# instrumented_app = Flask(...)
+# ***
+
+flask_config.trace_all = True  # If False, will only trace those manually decorated with
+# @tracer.trace('my_attr', 'another_attr'):
+# https://github.com/opentracing-contrib/python-flask#trace-individual-requests
+# You can access your instrumented app tracer with:
+# tracer = app.config['FLASK_TRACER']
+
+flask_config.traced_attributes = ['my_attr', 'another_attr']  # Ignored if flask_config.trace_all is False.
+
+# Ignored if tracer argument provided to instrument() or auto_instrument()
+flask_config.tracer = MyTracer()
+
+auto_instrument()  # or instrument(flask=True)
+
+app = flask.Flask(__name__)
+bp = flask.Blueprint('form_letter', __name__)
+
+
+@app.route('/healthcheck')
+def healthcheck()
+    self.write('In Good Spirits!')
+
+
+@bp.route('/<letter>', methods=['GET', 'POST'])
+def collate(letter)
+    self.write('Thank You!')
+
+
+app.register_blueprint(bp, url_prefix='/letters')
+
+if __name__ == "__main__":
+    app.run()
+```

--- a/signalfx_tracing/libraries/flask_/__init__.py
+++ b/signalfx_tracing/libraries/flask_/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from .instrument import config, instrument, uninstrument  # noqa

--- a/signalfx_tracing/libraries/flask_/instrument.py
+++ b/signalfx_tracing/libraries/flask_/instrument.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from flask_opentracing import FlaskTracer
+from wrapt import wrap_function_wrapper
+import opentracing
+
+from signalfx_tracing import utils
+
+
+# Configures Flask tracing as described by
+# https://github.com/opentracing-contrib/python-flask/blob/master/README.rst
+config = utils.Config(
+    trace_all=True,
+    traced_attributes=['path', 'method'],
+    tracer=None,
+)
+
+
+def instrument(tracer=None):
+    flask = utils.get_module('flask')
+    if utils.is_instrumented(flask):
+        return
+
+    def flask_tracer(__init__, app, args, kwargs):
+        """
+        A function wrapper of flask.Flask.__init__ to create a corresponding
+        flask_opentracing.FlaskTracer upon app instantiation.
+        """
+
+        __init__(*args, **kwargs)
+
+        _tracer = tracer or config.tracer or opentracing.tracer
+
+        app.config['FLASK_TRACER'] = FlaskTracer(
+            tracer=_tracer, trace_all_requests=config.trace_all,
+            app=app, traced_attributes=config.traced_attributes
+        )
+
+    wrap_function_wrapper('flask', 'Flask.__init__', flask_tracer)
+    utils.mark_instrumented(flask)
+
+
+def uninstrument():
+    """
+    Will only prevent new applications from registering tracers.
+    It's not reasonably feasible to remove existing before/after_request
+    trace methods of existing apps.
+    """
+    flask = utils.get_module('flask')
+    if not utils.is_instrumented(flask):
+        return
+
+    utils.revert_wrapper(flask.Flask, '__init__')
+    utils.mark_uninstrumented(flask)

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -2,6 +2,8 @@
 import importlib
 import sys
 
+from wrapt import ObjectProxy
+
 from .constants import instrumented_attr
 
 
@@ -37,3 +39,10 @@ class Config(object):
 
     def __setitem__(self, item, value):
         self.__dict__[item] = value
+
+
+def revert_wrapper(obj, wrapped_attr):
+    """Reverts a wrapt.wrap_function_wrapper() invocation"""
+    attr = getattr(obj, wrapped_attr, None)
+    if attr is not None and isinstance(attr, ObjectProxy) and hasattr(attr, '__wrapped__'):
+        setattr(obj, wrapped_attr, attr.__wrapped__)

--- a/tests/integration/flask_/__init__.py
+++ b/tests/integration/flask_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/integration/flask_/app.py
+++ b/tests/integration/flask_/app.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import flask
+
+
+app = flask.Flask('MyFlaskApplication')
+
+
+@app.route('/hello/<username>', methods=['GET', 'POST', 'PATCH', 'PUT', 'DELETE'])
+def my_route(username):
+    return 'Hello, {}!'.format(username)
+
+
+bp = flask.Blueprint('MyBlueprint', 'MyFlaskApplication')
+
+
+@bp.route('/<page>', methods=['GET', 'POST', 'PATCH', 'PUT', 'DELETE'])
+def my_blueprint_route(page):
+    return 'Rendering {}'.format(page)
+
+
+app.register_blueprint(bp, url_prefix='/bp')

--- a/tests/integration/flask_/test_instrumented_app.py
+++ b/tests/integration/flask_/test_instrumented_app.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from time import sleep
+
+from opentracing.mocktracer import MockTracer
+from threading import Thread
+import requests
+import pytest
+import six
+
+from signalfx_tracing.libraries import flask_config
+from signalfx_tracing import auto_instrument
+
+
+app_endpoint = 'http://127.0.0.1:32321/hello/MyName'
+bp_endpoint = 'http://127.0.0.1:32321/bp/MyPage'
+
+
+class TestFlaskApp(object):
+
+    _app_store = [None]     # pytest doesn't persist attributes set in class-scoped autouse
+    _tracer_store = [None]  # fixtures, so use stores as a hack.
+
+    @property
+    def app(self):
+        return self._app_store[0]
+
+    @property
+    def tracer(self):
+        return self._tracer_store[0]
+
+    @classmethod
+    @pytest.fixture(scope='class', autouse=True)
+    def instrumented_app(cls):
+        tracer = MockTracer()
+        cls._tracer_store[0] = tracer
+
+        flask_config.traced_attributes = ['path', 'method', 'query_string', 'blueprint']
+
+        auto_instrument(tracer)
+
+        from .app import app
+        cls._app_store[0] = app
+
+        app_thread = Thread(target=cls.run_app)
+        app_thread.daemon = True
+        app_thread.start()
+
+        for i in range(20):  # Wait for application to accept connections.
+            try:
+                requests.get(app_endpoint)
+                break
+            except Exception:
+                if i == 19:
+                    raise
+                sleep(.25)
+
+        tracer.reset()
+
+        yield
+
+    @classmethod
+    def run_app(cls):
+        cls._app_store[0].run(host='127.0.0.1', port=32321)
+
+    @pytest.fixture(autouse=True)
+    def reset_tracer(self):
+        yield
+        self.tracer.reset()
+
+    @pytest.mark.parametrize('http_method', ('get', 'head', 'post', 'delete',
+                                             'patch', 'put', 'options'))
+    def test_traced_app_request(self, http_method):
+        query = 'one=1&two=2'
+        method = getattr(requests, http_method)
+        assert method('{}?{}'.format(app_endpoint, query)).status_code == 200
+
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans.pop()
+        assert span.operation_name == 'my_route'
+        tagged_method = http_method.upper()
+        expected_query_string = query if six.PY2 else str(bytes(query, 'ascii'))
+        assert span.tags == {'method': tagged_method,
+                             'path': '/hello/MyName',
+                             'query_string': expected_query_string,
+                             'blueprint': 'None',
+                             'Extract failed': ''}
+
+    @pytest.mark.parametrize('http_method', ('get', 'head', 'post', 'delete',
+                                             'patch', 'put', 'options'))
+    def test_traced_blueprint_request(self, http_method):
+        query = 'one=1&two=2'
+        method = getattr(requests, http_method)
+        assert method('{}?{}'.format(bp_endpoint, query)).status_code == 200
+
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans.pop()
+        assert span.operation_name == 'MyBlueprint.my_blueprint_route'
+        tagged_method = http_method.upper()
+        expected_query_string = query if six.PY2 else str(bytes(query, 'ascii'))
+        assert span.tags == {'method': tagged_method,
+                             'path': '/bp/MyPage',
+                             'query_string': expected_query_string,
+                             'blueprint': 'MyBlueprint',
+                             'Extract failed': ''}

--- a/tests/unit/libraries/flask_/__init__.py
+++ b/tests/unit/libraries/flask_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/unit/libraries/flask_/conftest.py
+++ b/tests/unit/libraries/flask_/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import pytest
+
+from signalfx_tracing.libraries.flask_.instrument import config, uninstrument
+
+
+class FlaskTestSuite(object):
+
+    @pytest.fixture(autouse=True)
+    def restored_flask_config(self):
+        orig = dict(config.__dict__)
+        yield
+        config.__dict__ = orig
+
+    @pytest.fixture(autouse=True)
+    def uninstrument_flask(self):
+        yield
+        uninstrument()

--- a/tests/unit/libraries/flask_/test_flask.py
+++ b/tests/unit/libraries/flask_/test_flask.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from opentracing.mocktracer import MockTracer
+from flask_opentracing import FlaskTracer
+import opentracing
+import pytest
+import flask
+
+from signalfx_tracing.libraries.flask_ import config, instrument, uninstrument
+from .conftest import FlaskTestSuite
+
+
+class TestFlaskConfig(FlaskTestSuite):
+
+    @pytest.mark.parametrize('trace_all', (True, False))
+    def test_instrument_flask_values_set_by_config(self, trace_all):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.trace_all = trace_all
+        # config.traced_attributes adoption is not exposed
+
+        instrument()
+        app = flask.Flask('MyFlaskApplication')
+
+        flask_tracer = app.config['FLASK_TRACER']
+        assert isinstance(flask_tracer, FlaskTracer)
+        assert flask_tracer._tracer is tracer
+        if trace_all:
+            assert 'start_trace' in str(app.before_request_funcs.get(None))
+            assert 'end_trace' in str(app.after_request_funcs.get(None))
+        else:
+            assert 'start_trace' not in str(app.before_request_funcs.get(None))
+            assert 'end_trace' not in str(app.after_request_funcs.get(None))
+
+
+class TestFlaskApplication(FlaskTestSuite):
+
+    def make_app(self):
+        app = flask.Flask('MyFlaskApplication')
+
+        @app.route('/')
+        def my_route():
+            return 'Success!'
+
+        return app
+
+    def test_trace_with_default_config(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        instrument()
+        app = self.make_app()
+
+        flask_tracer = app.config['FLASK_TRACER']
+        assert flask_tracer._tracer is tracer
+
+        client = app.test_client()
+        assert client.get('/').status_code == 200
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.operation_name == 'my_route'
+        assert span.tags == {'Extract failed': '', 'method': 'GET', 'path': '/'}
+
+    def test_trace_with_specified_tracer_and_attributes(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.traced_attributes = ['url', 'blueprint', 'method']
+        instrument()
+        app = self.make_app()
+
+        flask_tracer = app.config['FLASK_TRACER']
+        assert flask_tracer._tracer is tracer
+
+        client = app.test_client()
+        assert client.get('/').status_code == 200
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.operation_name == 'my_route'
+        assert span.tags == {'Extract failed': '', 'method': 'GET',
+                             'url': 'http://localhost/', 'blueprint': 'None'}
+
+    def test_trace_without_trace_all(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.trace_all = False
+        instrument()
+        app = self.make_app()
+
+        flask_tracer = app.config['FLASK_TRACER']
+        assert flask_tracer._tracer is tracer
+
+        client = app.test_client()
+        assert client.get('/').status_code == 200
+
+        assert not tracer.finished_spans()
+
+    def test_uninstrument_reverts_wrapper(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        instrument()
+        app = self.make_app()
+
+        client = app.test_client()
+        assert client.get('/').status_code == 200
+
+        assert len(tracer.finished_spans()) == 1
+
+        tracer.reset()
+
+        uninstrument()
+        app = self.make_app()
+
+        client = app.test_client()
+        assert client.get('/').status_code == 200
+
+        assert tracer.finished_spans() == []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 import sys
 
+from wrapt import wrap_function_wrapper
 import pytest
 
 from signalfx_tracing import utils, constants
@@ -54,3 +55,20 @@ def test_config_with_kwargs():
     cfg.one = 'one'
     assert cfg['one'] == 'one'
     assert cfg.one == 'one'
+
+
+def test_revert_wrapper():
+
+    class Namespace():
+
+        def wrappee(self, *args, **kwargs):
+            return 'wrappee'
+
+    def wrapper(self, *args, **kwargs):
+        return 'wrapper'
+
+    wrap_function_wrapper(Namespace, 'wrappee', wrapper)
+    assert Namespace().wrappee() == 'wrapper'
+
+    utils.revert_wrapper(Namespace, 'wrappee')
+    assert Namespace().wrappee() == 'wrappee'

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist=
     py{34,35,36}-django20
     py{35,36}-django21
     py{27,34,35,36}-tornado{43,44,45,50,51}
+    py{27,34,35,36}-flask{010,011,012,10}
 
 [testenv]
 basepython =
@@ -32,6 +33,12 @@ deps =
     tornado50: tornado>=5.0,<5.1
     tornado51: tornado>=5.1,<5.2
     tornado{43,44,45,50,51}: requests
+    flask010: flask>=0.10,<0.11
+    flask011: flask>=0.11,<0.12
+    flask012: flask>=0.12,<0.13
+    flask10: flask>=1.0,<1.1
+    flask{010,011,012,10}: requests
+
 commands = 
     flake8: flake8 setup.py signalfx_tracing tests 
     py{27,34,35,36}-unit: pytest tests/unit --ignore tests/unit/libraries -p no:django
@@ -39,6 +46,8 @@ commands =
     django{18,19,110,111,20,21}: pytest tests/integration/django_
     tornado{43,44,45,50,51}: pytest tests/unit/libraries/tornado_
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
+    flask{010,011,012,10}: pytest tests/unit/libraries/flask_
+    flask{010,011,012,10}: pytest tests/integration/flask_
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Provides auto-instrumenter (function wrapper) and test coverage for https://github.com/opentracing-contrib/python-flask.  Adoption of OT 2.0-compatible python-flask will be in subsequent PR when https://github.com/opentracing-contrib/python-flask/tree/v1.0.0 or a fork has adopted the new span creation interface.