### PR TITLE
Initial PyMySQL support

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,5 @@ django
 pytest-django
 tornado
 requests
+pymysql
+docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 https://github.com/rmfitzpatrick/opentracing-python/tarball/flask_scope_manager#egg=opentracing
 https://github.com/rmfitzpatrick/python-flask/tarball/use_flask_scope_manager#egg=flask_opentracing
 https://github.com/rmfitzpatrick/python-django/tarball/django_2_ot_2#egg=django-opentracing
+git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing
 tornado_opentracing
 wrapt

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 
 instrumented_attr = '__sfx_instrumented'
-traceable_libraries = ('django', 'flask', 'tornado')
-auto_instrumentable_libraries = ('flask', 'tornado')
+traceable_libraries = ('django', 'flask', 'pymysql', 'tornado')
+auto_instrumentable_libraries = ('flask', 'pymysql', 'tornado')

--- a/signalfx_tracing/instrumentation.py
+++ b/signalfx_tracing/instrumentation.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 import logging
 import pkgutil
+import sys
 
 from .constants import traceable_libraries, auto_instrumentable_libraries
 from .utils import get_module
@@ -22,7 +23,7 @@ def _importable_libraries(*libraries):
     available = []
     unavailable = []
     for library in libraries:
-        if pkgutil.find_loader(library) is not None:
+        if library in sys.modules or pkgutil.find_loader(library) is not None:
             available.append(library)
         else:
             unavailable.append(library)

--- a/signalfx_tracing/libraries/__init__.py
+++ b/signalfx_tracing/libraries/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 from .django_ import config as django_config  # noqa
 from .flask_ import config as flask_config  # noqa
+from .pymysql_ import config as pymysql_config  # noqa
 from .tornado_ import config as tornado_config  # noqa

--- a/signalfx_tracing/libraries/flask_/README.md
+++ b/signalfx_tracing/libraries/flask_/README.md
@@ -13,7 +13,7 @@ request attributes for span tagging:
 | -------------|------------|---------------|
 | trace_all | Whether to trace all requests. | `True` |
 | traced_attributes | [Request attributes](http://flask.pocoo.org/docs/1.0/api/#flask.Request) to use as span tags. | `['path', 'method']` |
-| tracer | An instance of an OpenTracing-compatible tracer for all Tornado traces. | `opentracing.tracer` |
+| tracer | An instance of an OpenTracing-compatible tracer for all Flask traces. | `opentracing.tracer` |
 
 ```python
 # my_app.py

--- a/signalfx_tracing/libraries/pymysql_/README.md
+++ b/signalfx_tracing/libraries/pymysql_/README.md
@@ -1,0 +1,60 @@
+# PyMySQL
+
+- [signalfx/python-dbapi](https://github.com/signalfx/python-dbapi)
+- [Official Site](https://pymysql.readthedocs.io)
+
+The SignalFx Auto-instrumenter configures the OpenTracing DB API instrumentation for your PyMySQL
+connections.  You can enable instrumentation within your connection and `Cursor` commands by invoking the
+`signalfx_tracing.auto_instrument()` function before initializing your `Connection` client object.
+To configure tracing, some tunables are provided via `pymysql_config` to establish the desired tracer and
+database commands for span tagging:
+
+| Setting name | Definition | Default value |
+| -------------|------------|---------------|
+| traced_commands | [Cursor](https://www.python.org/dev/peps/pep-0249/#cursor-methods) and [Connection](https://www.python.org/dev/peps/pep-0249/#connection-methods) methods for which to create spans. | All supported: `['execute', 'executemany', 'callproc', 'commit', 'rollback']` |
+| span_tags | Span tag names and values, as a dictionary, with which to tag all PyMySQL spans. | `{}` |
+| tracer | An instance of an OpenTracing-compatible tracer for all PyMySQL traces. | `opentracing.tracer` |
+
+```python
+# my_app.py
+from signalfx_tracing import auto_instrument, instrument
+from signalfx_tracing.libraries import pymysql_config 
+
+import pymysql
+
+# ***
+# The SignalFx PyMySQL Auto-instrumenter works by monkey patching the pymysql.connect() method.
+# You must invoke auto_instrument() or instrument() before instantiating your client connection.
+#
+# from sfx_tracing import instrument
+# instrument(pymysql=True)  # or sfx_tracing.auto_instrument()
+# traced_connection = pymysql.connect(...)
+#
+# Accessing connect() from its parent pymysql module object requires no advanced instrumentation
+# beyond that of pre-initialization.  If you are importing connect() from pymysql directly, you
+# must instrument before doing so:
+#
+# from sfx_tracing import instrument
+# instrument(pymysql=True)  # or sfx_tracing.auto_instrument()
+#
+# from pymysql import connect
+# traced_connection = connect(...)
+# ***
+
+pymysql_config.traced_commands = ['executemany', 'rollback']  # other supported commands are
+                                                              # 'execute', 'callproc', 'commit', and 'rollback'
+pymysql_config.span_tags = dict(my_helpful_identifier='green')
+pymysql_config.tracer = MyTracer()
+
+auto_instrument()  # or instrument(pymysql=True)
+
+traced_connection = pymysql.connect(...)
+
+# In this example, any failing command/query will lead to a traced rollback().
+# Successful commands will exit the context with an untraced commit().
+with traced_connection as cursor():
+    cursor.executemany('insert into table values (%s, %s)',
+                       [('my', 'value'), ('another', 'value')])
+    cursor.callproc('StoredProcedure')  # untraced per pymysql_config.traced_commands
+
+```

--- a/signalfx_tracing/libraries/pymysql_/__init__.py
+++ b/signalfx_tracing/libraries/pymysql_/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from .instrument import config, instrument, uninstrument  # noqa

--- a/signalfx_tracing/libraries/pymysql_/instrument.py
+++ b/signalfx_tracing/libraries/pymysql_/instrument.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import logging
+
+from dbapi_opentracing import ConnectionTracing, Cursor
+from wrapt import wrap_function_wrapper
+import opentracing
+
+from signalfx_tracing import utils
+
+
+log = logging.getLogger(__name__)
+
+
+# Configures PyMySQL tracing as described by
+# https://github.com/signalfx/python-dbapi/blob/master/README.rst
+config = utils.Config(
+    traced_commands=['execute', 'executemany', 'callproc', 'commit', 'rollback'],
+    span_tags=None,
+    tracer=None,
+)
+
+traceable_connection_commands = set(('commit', 'rollback'))
+traceable_cursor_commands = set(('execute', 'executemany', 'callproc'))
+
+
+def instrument(tracer=None):
+    pymysql = utils.get_module('pymysql')
+    if utils.is_instrumented(pymysql):
+        return
+
+    pymysql_cursors = utils.get_module('pymysql.cursors')
+
+    def pymysql_tracer(connect, _, args, kwargs):
+        """
+        A function wrapper of pymysql.connect() to create a corresponding
+        dbapi_opentracing.ConnectionTracing upon database connection.
+        """
+
+        connection = connect(*args, **kwargs)
+        _tracer = tracer or config.tracer or opentracing.tracer
+        tracing = ConnectionTracing(connection, _tracer, span_tags=config.span_tags)
+
+        traced_commands = set(config.traced_commands)
+        for command in traced_commands:
+            if command not in traceable_connection_commands and command not in traceable_cursor_commands:
+                log.warn('Unable to trace PyMySQL command "{}".  Ignoring.'.format(command))
+
+        # Revert undesired traced commands by wrapping with originals
+        for undesired_command in (traceable_connection_commands - traced_commands):
+            wrapped = getattr(tracing.__wrapped__, undesired_command)
+            wrap_function_wrapper(tracing, undesired_command, wrapped)
+
+        for undesired_command in (traceable_cursor_commands - traced_commands):
+            wrapped = getattr(pymysql_cursors.Cursor, undesired_command)
+            # We must wrap our wrapper class for subsequent cursor() invocations
+            wrap_function_wrapper(Cursor, undesired_command, wrapped)
+
+        return tracing
+
+    wrap_function_wrapper('pymysql', 'connect', pymysql_tracer)
+    utils.mark_instrumented(pymysql)
+
+
+def uninstrument():
+    """
+    Will only prevent new Connections from registering tracers.
+    It's not reasonably feasible to unwrap existing ConnectionTracing instances
+    """
+    pymysql = utils.get_module('pymysql')
+    if not utils.is_instrumented(pymysql):
+        return
+
+    connections = utils.get_module('pymysql.connections')
+    cursors = utils.get_module('pymysql.cursors')
+    utils.revert_wrapper(pymysql, 'connect')
+    utils.revert_wrapper(connections.Connection, 'commit')
+    utils.revert_wrapper(connections.Connection, 'rollback')
+    utils.revert_wrapper(cursors.Cursor, 'execute')
+    utils.revert_wrapper(cursors.Cursor, 'executemany')
+    utils.revert_wrapper(cursors.Cursor, 'callproc')
+
+    # Revert blacklist
+    utils.revert_wrapper(Cursor, 'execute')
+    utils.revert_wrapper(Cursor, 'executemany')
+    utils.revert_wrapper(Cursor, 'callproc')
+
+    utils.mark_uninstrumented(pymysql)

--- a/tests/integration/pymysql_/__init__.py
+++ b/tests/integration/pymysql_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/integration/pymysql_/conf.d/testing.cnf
+++ b/tests/integration/pymysql_/conf.d/testing.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password

--- a/tests/integration/pymysql_/initdb.d/db.sql
+++ b/tests/integration/pymysql_/initdb.d/db.sql
@@ -1,0 +1,37 @@
+drop database if exists `test_db`;
+create database `test_db` DEFAULT CHARACTER SET utf8mb4;
+
+drop user if exists 'test_user';
+create user 'test_user'@'%' identified by 'test_password';
+grant all on test_db.* TO 'test_user'@'%';
+
+use test_db;
+drop table if exists `table_one`;
+create table `table_one` (
+    `string_one` varchar(64) not null,
+    `string_two` varchar(64),
+    `datetime_one` datetime not null,
+    `datetime_two` datetime,
+    primary key (`string_one`)
+);
+
+drop table if exists `table_two`;
+create table `table_two` (
+    `int_one` int(10) not null,
+    `int_two` int(10),
+    `float_one` float(11,4) not null,
+    `float_two` float(11,4),
+    primary key (`int_one`)
+);
+
+delimiter $$
+create procedure test_procedure_one()
+begin
+    select * from table_one, table_two;
+end$$
+
+create procedure test_procedure_two()
+begin
+    select * from table_one, table_two;
+end$$
+delimiter ;

--- a/tests/integration/pymysql_/test_instrumented_connection.py
+++ b/tests/integration/pymysql_/test_instrumented_connection.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from random import choice, random, randint
+from datetime import datetime
+from time import sleep
+import os.path
+import string
+
+from opentracing.mocktracer import MockTracer
+from pymysql.cursors import DictCursor
+from opentracing.ext import tags
+import pymysql
+import docker
+import pytest
+
+from signalfx_tracing.libraries import pymysql_config
+from signalfx_tracing import instrument
+
+
+@pytest.fixture(scope='session')
+def mysql_container():
+    client = docker.from_env()
+    env = dict(MYSQL_ROOT_PASSWORD='pass',
+               MYSQL_ROOT_HOST='%')
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    conf_d = os.path.join(cwd, 'conf.d')
+    initdb_d = os.path.join(cwd, 'initdb.d')
+    volumes = ['{}:/etc/mysql/conf.d'.format(conf_d),
+               '{}:/docker-entrypoint-initdb.d'.format(initdb_d)]
+    mysql = client.containers.run('mysql:latest', environment=env, ports={'3306/tcp': 3306},
+                                  volumes=volumes, detach=True)
+    try:
+        yield mysql
+    finally:
+        mysql.remove(v=True, force=True)
+
+
+class TestInstrumentedConnection(object):
+
+    def fmt_time(self, ts):
+        return ts.strftime('%Y-%m-%d %H:%M:%S')
+
+    _strings = set()
+    _ints = set()
+    _floats = set()
+
+    def random_string(self):
+        while True:
+            s = ''.join(choice(string.ascii_lowercase) for _ in range(10))
+            if s not in self._strings:
+                self._strings.add(s)
+                return s
+
+    def random_int(self):
+        while True:
+            i = randint(0, 100000)
+            if i not in self._ints:
+                self._ints.add(i)
+                return i
+
+    def random_float(self):
+        while True:
+            i = random() * 100000
+            if i not in self._floats:
+                self._floats.add(i)
+                return i
+
+    @pytest.fixture
+    def connection_tracing(self, mysql_container):
+        tracer = MockTracer()
+        pymysql_config.tracer = tracer
+        pymysql_config.span_tags = dict(some='tag')
+        instrument(pymysql=True)
+        for i in range(480):
+            try:
+                conn = pymysql.connect(host='127.0.0.1', user='test_user', password='test_password',
+                                       db='test_db', port=3306, cursorclass=DictCursor)
+                break
+            except pymysql.OperationalError:
+                sleep(.25)
+            if i == 479:
+                raise Exception('Failed to connect to MySQL: {}'.format(mysql_container.logs()))
+        return tracer, conn
+
+    def test_instrumented_sanity(self, connection_tracing):
+        tracer, conn = connection_tracing
+        with tracer.start_active_span('Parent'):
+            with conn.cursor() as cursor:
+                cursor.execute('insert into table_one values (%s, %s, %s, %s)',
+                               (self.random_string(), self.random_string(),
+                                datetime.now(), datetime.now()))
+                cursor.execute('insert into table_two values (%s, %s, %s, %s)',
+                               (self.random_int(), self.random_int(),
+                                self.random_float(), self.random_float()))
+            conn.commit()
+        spans = tracer.finished_spans()
+        assert len(spans) == 4
+        first, second, commit, parent = spans
+        for span in (first, second):
+            assert span.operation_name == 'DictCursor.execute(insert)'
+            assert span.tags['some'] == 'tag'
+            assert span.tags[tags.DATABASE_TYPE] == 'sql'
+            assert span.tags['db.rows_produced'] == 1
+            assert span.parent_id == parent.context.span_id
+            assert tags.ERROR not in span.tags
+        assert first.tags[tags.DATABASE_STATEMENT] == 'insert into table_one values (%s, %s, %s, %s)'
+        assert second.tags[tags.DATABASE_STATEMENT] == 'insert into table_two values (%s, %s, %s, %s)'
+        assert commit.operation_name == 'Connection.commit()'
+        assert parent.operation_name == 'Parent'

--- a/tests/unit/libraries/pymysql_/__init__.py
+++ b/tests/unit/libraries/pymysql_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/unit/libraries/pymysql_/conftest.py
+++ b/tests/unit/libraries/pymysql_/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import pytest
+
+from signalfx_tracing.libraries.pymysql_.instrument import config, uninstrument
+
+
+class PyMySQLTestSuite(object):
+
+    @pytest.fixture(autouse=True)
+    def restored_pymysql_config(self):
+        orig = dict(config.__dict__)
+        yield
+        config.__dict__ = orig
+
+    @pytest.fixture(autouse=True)
+    def uninstrument_pymysql(self):
+        yield
+        uninstrument()

--- a/tests/unit/libraries/pymysql_/test_pymysql.py
+++ b/tests/unit/libraries/pymysql_/test_pymysql.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import types
+
+from opentracing.mocktracer import MockTracer
+from mock import Mock, MagicMock
+import pymysql.connections
+import pymysql.cursors
+import opentracing
+import pymysql
+import mock
+
+from signalfx_tracing.libraries.pymysql_.instrument import config, instrument, uninstrument
+from .conftest import PyMySQLTestSuite
+
+
+class MockDBAPICursor(Mock):
+
+    execute = MagicMock(spec=types.MethodType)
+    execute.__name__ = 'execute'
+
+    executemany = MagicMock(spec=types.MethodType)
+    executemany.__name__ = 'executemany'
+
+    callproc = MagicMock(spec=types.MethodType)
+    callproc.__name__ = 'callproc'
+
+    rowcount = 'SomeRowCount'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return self
+
+
+class MockDBAPIConnection(Mock):
+
+    commit = MagicMock(spec=types.MethodType)
+    commit.__name__ = 'commit'
+
+    rollback = MagicMock(spec=types.MethodType)
+    rollback.__name__ = 'rollback'
+
+    def cursor(self):
+        return MockDBAPICursor()
+
+    def __exit__(self, exc, value, tb):
+        if exc:
+            return self.rollback()
+        return self.commit()
+
+
+class TestPyMySQL(PyMySQLTestSuite):
+
+    def test_noninstrumented_connection_does_not_trace(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.execute('traced')
+                    cursor.executemany('traced')
+                    cursor.callproc('traced')
+
+        assert not tracer.finished_spans()
+
+    def test_uninstrumented_connections_no_longer_traces(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                instrument(tracer)
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.execute('traced')
+                    cursor.executemany('traced')
+                    cursor.callproc('traced')
+
+                spans = tracer.finished_spans()
+                assert len(spans) == 3
+                assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
+                assert spans[1].operation_name == 'MockDBAPICursor.executemany(traced)'
+                assert spans[2].operation_name == 'MockDBAPICursor.callproc(traced)'
+
+                uninstrument()
+                tracer.reset()
+
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.execute('traced')
+                    cursor.executemany('traced')
+                    cursor.callproc('traced')
+
+                assert not tracer.finished_spans()
+
+
+class TestPyMySQLConfig(PyMySQLTestSuite):
+
+    def test_global_tracer_used_by_default(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                instrument()
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.execute('traced')
+                    cursor.executemany('traced')
+                    cursor.callproc('traced')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 3
+        assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
+        assert spans[1].operation_name == 'MockDBAPICursor.executemany(traced)'
+        assert spans[2].operation_name == 'MockDBAPICursor.callproc(traced)'
+
+    def test_cursor_commands_are_traced_by_default(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                instrument()
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.execute('traced')
+                    cursor.executemany('traced')
+                    cursor.callproc('traced')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 3
+        assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
+        assert spans[1].operation_name == 'MockDBAPICursor.executemany(traced)'
+        assert spans[2].operation_name == 'MockDBAPICursor.callproc(traced)'
+
+    def test_undesired_cursor_commands_are_not_traced(self):
+        config.traced_commands = ['execute']
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                instrument()
+                connection = pymysql.connect()
+                with connection.cursor() as cursor:
+                    cursor.executemany('untraced')
+                    cursor.callproc('untraced')
+                    cursor.execute('traced')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
+
+    def test_connection_commands_are_traced_by_default(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                with mock.patch.object(pymysql.cursors.Cursor, 'callproc',
+                                       side_effect=Exception) as callproc:
+                    callproc.__name__ = 'callproc'
+
+                    instrument()
+                    connection = pymysql.connect()
+                    with connection as cursor:
+                        cursor.execute('traced')
+
+                    spans = tracer.finished_spans()
+                    assert len(spans) == 2
+                    assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
+                    assert spans[1].operation_name == 'MockDBAPIConnection.commit()'
+
+                    tracer.reset()
+                    with connection as cursor:
+                        cursor.callproc('traced')
+
+                    spans = tracer.finished_spans()
+                    assert len(spans) == 2
+                    assert spans[0].operation_name == 'MockDBAPICursor.callproc(traced)'
+                    assert spans[1].operation_name == 'MockDBAPIConnection.rollback()'
+
+    def test_undesired_connection_commands_are_not_traced(self):
+        config.traced_commands = ['rollback']
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                with mock.patch.object(pymysql.cursors.Cursor, 'callproc',
+                                       side_effect=Exception) as callproc:
+                    callproc.__name__ = 'callproc'
+
+                    instrument()
+                    connection = pymysql.connect()
+                    with connection as cursor:
+                        cursor.executemany('untraced')
+                        cursor.execute('traced')
+
+                    assert not tracer.finished_spans()
+
+                    with connection as cursor:
+                        cursor.callproc('untraced')
+
+                    spans = tracer.finished_spans()
+                    assert len(spans) == 1
+                    assert spans[0].operation_name == 'MockDBAPIConnection.rollback()'
+
+    def test_span_tags_are_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.span_tags = dict(custom='tag')
+
+        with mock.patch.object(pymysql.connections, 'Connection', MockDBAPIConnection):
+            with mock.patch.object(pymysql.cursors, 'Cursor', MockDBAPICursor):
+                instrument()
+                connection = pymysql.connect()
+                with connection as cursor:
+                    cursor.executemany('traced')
+                    cursor.execute('traced')
+
+                spans = tracer.finished_spans()
+                assert len(spans) == 3
+                assert spans[0].operation_name == 'MockDBAPICursor.executemany(traced)'
+                assert spans[1].operation_name == 'MockDBAPICursor.execute(traced)'
+                assert spans[2].operation_name == 'MockDBAPIConnection.commit()'
+                for span in spans:
+                    assert span.tags['custom'] == 'tag'

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -22,8 +22,8 @@ else:
             yield
 
 
-expected_traceable_libraries = ('django', 'flask', 'tornado')
-expected_auto_instrumentable_libraries = ('flask', 'tornado')
+expected_traceable_libraries = ('django', 'flask', 'pymysql', 'tornado')
+expected_auto_instrumentable_libraries = ('flask', 'pymysql', 'tornado')
 
 
 class TestInstrument(object):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist=
     py{35,36}-django21
     py{27,34,35,36}-tornado{43,44,45,50,51}
     py{27,34,35,36}-flask{010,011,012,10}
+    py{27,34,35,36}-pymysql{08,09}
 
 [testenv]
 basepython =
@@ -38,6 +39,9 @@ deps =
     flask012: flask>=0.12,<0.13
     flask10: flask>=1.0,<1.1
     flask{010,011,012,10}: requests
+    pymysql08: pymysql>=0.8,<0.9
+    pymysql09: pymysql>=0.9,<1.0
+    pymysql{08,09}: docker
 
 commands = 
     flake8: flake8 setup.py signalfx_tracing tests 
@@ -48,6 +52,8 @@ commands =
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
     flask{010,011,012,10}: pytest tests/unit/libraries/flask_
     flask{010,011,012,10}: pytest tests/integration/flask_
+    pymysql{08,09}: pytest tests/unit/libraries/pymysql_
+    pymysql{08,09}: pytest tests/integration/pymysql_
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Provides auto-instrumenter (function wrapper) and test coverage for https://github.com/signalfx/python-dbapi.  This is a private repo until ready for distribution, so a subsequent requirements update will be needed.