### PR TITLE
Add bootstrapper for instrumenters and Jaeger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SignalFx Python Auto-Instrumenter
+# SignalFx-Tracing: A Python OpenTracing Auto-Instrumenter
 
 This utility provides users with the ability of automatically configuring
 OpenTracing community-contributed [instrumentation libraries](https://github.com/opentracing-contrib)
@@ -33,3 +33,59 @@ uninstrument(django=False)  # removes previous instrumentation
 * [Flask](./signalfx_tracing/libraries/flask_/README.md) - `instrument(flask=True)`
 * [PyMySQL](./signalfx_tracing/libraries/pymysql_/README.md) - `instrument(pymysql=True)`
 * [Tornado](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`
+
+## Installation and Configuration
+
+For the most basic installation:
+```sh
+ $ git clone https://github.com/signalfx/signalfx-python-tracing && pip install ./signalfx-python-tracing
+```
+
+SignalFx-Tracing works by detecting your available libraries and frameworks and configuring
+instrumenters for distributed tracing via the Python
+[OpenTracing API 2.0](https://pypi.org/project/opentracing/2.0.0/).  As adoption of this API
+is done on a per-instrumenter basis, it's recommended that you use the helpful bootstrap
+utility for obtaining and installing feature-ready instrumenter versions, instead of the basic
+pip installation:
+
+```sh
+ $ ./bootstrap.py
+```
+
+Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide
+the option of installing a modified [Jaeger Client](https://github.com/jaegertracing/jaeger-client-python)
+ready for reporting to SignalFx:
+
+```sh
+ $ ./bootstrap.py --jaeger
+```
+
+You can obtain an instance of this tracer using the `signalfx_tracing.utils.create_tracer()` helper.
+
+```python
+from signalfx_tracing import create_tracer
+
+tracer = create_tracer('<MyAccessToken>', ...)  # sets the global opentracing.tracer by default
+
+# or by using the token environment variable:
+import os
+os.environ['SIGNALFX_ACCESS_TOKEN'] = '<MyAccessToken>'
+tracer = create_tracer()
+
+# or to disable setting the global tracer:
+tracer = create_tracer('<MyAccessToken>', set_global=False)
+```
+
+All other `create_tracer()` arguments are those that can be passed to a `jaeger_client.Config` constructor:
+```python
+from opentracing.scope_managers.tornado import TornadoScopeManager
+from signalfx_tracing import create_tracer
+
+tracer = create_tracer(
+    '<MyAccessToken>',
+    config={'sampler': {'type': 'const', 'param': 1},
+            'logging': True},
+    service_name='MyTracedApplication',
+    scope_manager=TornadoScopeManager
+)
+```

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+from argparse import ArgumentParser
+import subprocess
+import pkgutil
+import sys
+import os
+
+
+def is_installed(library):
+    return library in sys.modules or pkgutil.find_loader(library) is not None
+
+
+opentracing = 'https://github.com/rmfitzpatrick/opentracing-python/tarball/flask_scope_manager#egg=opentracing'
+jaeger_client = 'https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client'
+
+instrumenters = {
+    'flask': 'https://github.com/rmfitzpatrick/python-flask/tarball/use_flask_scope_manager#egg=flask-opentracing',
+    'django': 'https://github.com/rmfitzpatrick/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
+    'pymysql': 'git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing',
+    'tornado': 'tornado_opentracing',
+}
+
+
+if __name__ == '__main__':
+    ap = ArgumentParser()
+    ap.add_argument('--jaeger', action='store_true')
+    args = ap.parse_args()
+    cwd = os.path.abspath(os.path.dirname(__file__))
+
+    if args.jaeger:
+        print('Installing Jaeger Client.')
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', jaeger_client])
+
+    for library, instrumenter in instrumenters.items():
+        if is_installed(library):
+            print('Installing {} instrumenter.'.format(library))
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', instrumenter])
+
+    print('Installing SignalFx-Tracing.')
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-I', opentracing, cwd])

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setup(name='signalfx-tracing',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
       ],
-      packages=find_packages())
+      packages=find_packages(),
+      install_requires=['wrapt'])

--- a/signalfx_tracing/libraries/django_/README.md
+++ b/signalfx_tracing/libraries/django_/README.md
@@ -33,19 +33,14 @@ SIGNALFX_SET_GLOBAL_TRACER = True
 SIGNALFX_TRACER_CALLABLE = 'my_opentracing_compatible_tracer.Tracer'
 SIGNALFX_TRACER_PARAMETERS = dict(my_tracer_parameter='arg_one', another_parameter='arg_two')
 # ***
-# If using the Jaeger Python client, there is an known issue with
-# Tracer initialization before forking: 
+# If using the Jaeger Python client, there is a known issue with
+# tracer initialization before forking:
 # https://github.com/jaegertracing/jaeger-client-python/issues/60
-#
 # As a workaround in Django, this pattern is suggested:
 #
-# from jaeger_client import Config
-#
-# def create_tracer():
-#     config = Config(...)
-#     return config.initialize_tracer()
-#
-# SIGNALFX_TRACER_CALLABLE = 'my_app.settings.create_tracer'
+# SIGNALFX_TRACER_CALLABLE = 'signalfx_tracing.utils.create_tracer'
+# SIGNALFX_TRACER_PARAMETERS = dict(access_token='<MyAccessToken>',
+#                                   service_name='MyDjangoApp', ...)
 #
 # Please note that you must use a version of django_opentracing
 # that supports lazy tracer initialization, such as that found at

--- a/tests/integration/test_jaeger_client.py
+++ b/tests/integration/test_jaeger_client.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import os
+
+from jaeger_client import Config, Tracer
+import pytest
+
+from signalfx_tracing import utils
+
+
+env_var = 'SIGNALFX_ACCESS_TOKEN'
+
+
+class TestCreateTracer(object):
+
+    @pytest.fixture(autouse=True)
+    def reset_jaeger_environment(self):
+        Config._initialized = False
+        prev = None
+        try:
+            prev = os.environ.pop(env_var)
+        except KeyError:
+            pass
+        yield
+        if prev is not None:
+            os.environ[env_var] = prev
+
+    def test_creation_requires_access_token(self):
+        with pytest.raises(ValueError):
+            utils.create_tracer()
+
+    def test_creation_with_access_token_arg(self):
+        tracer = utils.create_tracer('AccessToken')
+        assert isinstance(tracer, Tracer)
+
+    def test_creation_with_access_token_env_var(self):
+        os.environ[env_var] = 'AccessToken'
+        tracer = utils.create_tracer()
+        assert isinstance(tracer, Tracer)
+
+    def test_access_token_provided_to_sender(self):
+        tracer = utils.create_tracer('auth_token')
+        assert tracer.reporter._sender.user == 'auth'
+        assert tracer.reporter._sender.password == 'auth_token'
+        assert tracer.reporter._sender.url == 'https://ingest.signalfx.com/v1/trace'
+
+    def test_defaults_overridden_by_config(self):
+        config = dict(service_name='SomeService',
+                      jaeger_user='SomeUser',
+                      jaeger_password='SomePassword',
+                      jaeger_endpoint='SomeEndpoint')
+        tracer = utils.create_tracer('auth_token', config=config)
+        assert tracer.reporter._sender.user == 'SomeUser'
+        assert tracer.reporter._sender.password == 'SomePassword'
+        assert tracer.reporter._sender.url == 'SomeEndpoint'

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist=
     py{27,34,35,36}-tornado{43,44,45,50,51}
     py{27,34,35,36}-flask{010,011,012,10}
     py{27,34,35,36}-pymysql{08,09}
+    py{27,34,35,36}-jaeger
 
 [testenv]
 basepython =
@@ -44,7 +45,7 @@ deps =
     pymysql{08,09}: docker
 
 commands = 
-    flake8: flake8 setup.py signalfx_tracing tests 
+    flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
     py{27,34,35,36}-unit: pytest tests/unit --ignore tests/unit/libraries -p no:django
     django{18,19,110,111,20,21}: pytest tests/unit/libraries/django_
     django{18,19,110,111,20,21}: pytest tests/integration/django_
@@ -54,6 +55,8 @@ commands =
     flask{010,011,012,10}: pytest tests/integration/flask_
     pymysql{08,09}: pytest tests/unit/libraries/pymysql_
     pymysql{08,09}: pytest tests/integration/pymysql_
+    jaeger: ./bootstrap.py --jaeger
+    jaeger: pytest tests/integration/test_jaeger_client.py
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Provides an oob installer for the current Jaeger client branch that supports OT 2.0 and HTTPSender.