### PR TITLE
Initial Requests support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ uninstrument(flask=False)  # prevent future registrations and
 * [Flask](./signalfx_tracing/libraries/flask_/README.md) - `instrument(flask=True)`
 * [PyMongo](./signalfx_tracing/libraries/pymongo_/README.md) - `instrument(pymongo=True)`
 * [PyMySQL](./signalfx_tracing/libraries/pymysql_/README.md) - `instrument(pymysql=True)`
+* [Requests](./signalfx_tracing/libraries/requests_/README.md) - `instrument(requests=True)`
 * [Tornado](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`
 
 ## Installation and Configuration

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -12,14 +12,15 @@ def is_installed(library):
     return library in sys.modules or pkgutil.find_loader(library) is not None
 
 
-opentracing = 'https://github.com/rmfitzpatrick/opentracing-python/tarball/flask_scope_manager#egg=opentracing'
+opentracing = 'https://github.com/signalfx/opentracing-python/tarball/flask_scope_manager#egg=opentracing'
 jaeger_client = 'https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client'
 
 instrumenters = {
-    'flask': 'https://github.com/rmfitzpatrick/python-flask/tarball/use_flask_scope_manager#egg=flask-opentracing',
-    'django': 'https://github.com/rmfitzpatrick/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
+    'flask': 'https://github.com/signalfx/python-flask/tarball/use_flask_scope_manager#egg=flask-opentracing',
+    'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
     'pymongo': 'git+ssh://git@github.com/signalfx/python-pymongo.git#egg=pymongo-opentracing',
     'pymysql': 'git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing',
+    'requests': 'git+ssh://git@github.com/signalfx/python-requests.git#egg=requests-opentracing',
     'tornado': 'tornado_opentracing',
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-https://github.com/rmfitzpatrick/opentracing-python/tarball/flask_scope_manager#egg=opentracing
-https://github.com/rmfitzpatrick/python-flask/tarball/use_flask_scope_manager#egg=flask_opentracing
-https://github.com/rmfitzpatrick/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing
+https://github.com/signalfx/opentracing-python/tarball/flask_scope_manager#egg=opentracing
+https://github.com/signalfx/python-flask/tarball/use_flask_scope_manager#egg=flask_opentracing
+https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing
 git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing
 git+ssh://git@github.com/signalfx/python-pymongo.git#egg=pymongo-opentracing
+git+ssh://git@github.com/signalfx/python-requests.git#egg=requests-opentracing
 tornado_opentracing
 wrapt

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 
 instrumented_attr = '__sfx_instrumented'
-traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'tornado')
-auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'tornado')
+traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'requests', 'tornado')
+auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'requests', 'tornado')

--- a/signalfx_tracing/instrumentation.py
+++ b/signalfx_tracing/instrumentation.py
@@ -52,7 +52,7 @@ def instrument(tracer=None, **libraries):
     for library, inst in libraries.items():
         if library not in traceable_libraries:
             log.warn('Unable to trace {}'.format(library))
-        if not inst:
+        elif not inst:
             uninstrument(library)
         else:
             imported_instrumenter(library).instrument(tracer)

--- a/signalfx_tracing/libraries/__init__.py
+++ b/signalfx_tracing/libraries/__init__.py
@@ -3,4 +3,5 @@ from .django_ import config as django_config  # noqa
 from .flask_ import config as flask_config  # noqa
 from .pymongo_ import config as pymongo_config  # noqa
 from .pymysql_ import config as pymysql_config  # noqa
+from .requests_ import config as requests_config # noqa
 from .tornado_ import config as tornado_config  # noqa

--- a/signalfx_tracing/libraries/django_/instrument.py
+++ b/signalfx_tracing/libraries/django_/instrument.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
-from django_opentracing import DjangoTracer
 import opentracing
 
 from signalfx_tracing import utils
@@ -49,7 +48,8 @@ def instrument(tracer=None):
     # Tracer initialization
     settings.OPENTRACING_SET_GLOBAL_TRACER = config.set_global_tracer
     if not config.set_global_tracer:
-        settings.OPENTRACING_TRACER = DjangoTracer(tracer)
+        django_opentracing = utils.get_module('django_opentracing')
+        settings.OPENTRACING_TRACER = django_opentracing.DjangoTracer(tracer)
     else:
         settings.OPENTRACING_TRACER_CALLABLE = config.tracer_callable
         settings.OPENTRACING_TRACER_PARAMETERS = config.tracer_parameters

--- a/signalfx_tracing/libraries/flask_/instrument.py
+++ b/signalfx_tracing/libraries/flask_/instrument.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
-from flask_opentracing import FlaskTracer
 from wrapt import wrap_function_wrapper
 import opentracing
 
@@ -20,6 +19,8 @@ def instrument(tracer=None):
     if utils.is_instrumented(flask):
         return
 
+    flask_opentracing = utils.get_module('flask_opentracing')
+
     def flask_tracer(__init__, app, args, kwargs):
         """
         A function wrapper of flask.Flask.__init__ to create a corresponding
@@ -30,7 +31,7 @@ def instrument(tracer=None):
 
         _tracer = tracer or config.tracer or opentracing.tracer
 
-        app.config['FLASK_TRACER'] = FlaskTracer(
+        app.config['FLASK_TRACER'] = flask_opentracing.FlaskTracer(
             tracer=_tracer, trace_all_requests=config.trace_all,
             app=app, traced_attributes=config.traced_attributes
         )

--- a/signalfx_tracing/libraries/pymongo_/instrument.py
+++ b/signalfx_tracing/libraries/pymongo_/instrument.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
-from pymongo_opentracing import CommandTracing
 from wrapt import wrap_function_wrapper
 import opentracing
 
@@ -19,6 +18,8 @@ def instrument(tracer=None):
     if utils.is_instrumented(pymongo):
         return
 
+    pymongo_opentracing = utils.get_module('pymongo_opentracing')
+
     def pymongo_tracer(__init__, app, args, kwargs):
         """
         A function wrapper of pymongo.MongoClient.__init__ to register a corresponding
@@ -26,7 +27,7 @@ def instrument(tracer=None):
         """
         _tracer = tracer or config.tracer or opentracing.tracer
 
-        command_tracing = CommandTracing(
+        command_tracing = pymongo_opentracing.CommandTracing(
             tracer=_tracer, span_tags=config.span_tags or {},
         )
 

--- a/signalfx_tracing/libraries/requests_/README.md
+++ b/signalfx_tracing/libraries/requests_/README.md
@@ -1,0 +1,56 @@
+# Requests
+
+- [signalfx/python-requests](https://github.com/signalfx/python-requests)
+- [Official Site](http://docs.python-requests.org/en/master/)
+
+The SignalFx Auto-instrumenter configures the OpenTracing Requests instrumentation for your Session commands.
+You can enable instrumentation within your http client by invoking the `signalfx_tracing.auto_instrument()`
+function before initializing your `Session` object or making api calls from the `requests` or `requests.api` modules. 
+To configure tracing, some tunables are provided via `requests_config` to establish the desired tracer,
+context propagation, and custom tag name and values for all created spans:
+
+| Setting name | Definition | Default value |
+| -------------|------------|---------------|
+| propagate | Whether to propagate current trace via request headers. Only use if client reaches your services exclusively | `False` |
+| span_tags | Span tag names and values, as a dictionary, with which to tag all Requests spans. | `{}` |
+| tracer | An instance of an OpenTracing-compatible tracer for all Requests traces. | `opentracing.tracer` |
+
+```python
+# my_app.py
+from signalfx_tracing import auto_instrument, instrument
+from signalfx_tracing.libraries import requests_config 
+import requests
+
+# ***
+# The SignalFx Requests Auto-instrumenter works by monkey patching the requests.sessions.Session.__init__() method.
+# You must invoke auto_instrument() or instrument() before instantiating your client session or making requests
+# from the top-level requests package. 
+#
+# import requests.sessions
+# from sfx_tracing import instrument
+# instrument(requests=True)  # or sfx_tracing.auto_instrument()
+# traced_session = requests.sessions.Session()
+#
+# Accessing or importing Session from its parent requests or requests.sessions module objects
+# requires no advanced instrumentation beyond that of pre-initialization.
+#
+# from sfx_tracing import instrument
+# from requests import Session, get, post
+# instrument(requests=True)  # or sfx_tracing.auto_instrument()
+#
+# traced_session = Session()
+# traced_get_response = get(...)
+# traced_post_response = post(...)
+# ***
+
+requests_config.propagate = True
+requests_config.span_tags = dict(my_helpful_identifier='green')
+requests_config.tracer = MyTracer()
+
+auto_instrument()  # or instrument(requests=True)
+
+traced_get_response = requests.get(...)
+
+traced_session = requests.Session()
+traced_post_response = traced_session.post(...)
+```

--- a/signalfx_tracing/libraries/requests_/__init__.py
+++ b/signalfx_tracing/libraries/requests_/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from .instrument import config, instrument, uninstrument  # noqa

--- a/signalfx_tracing/libraries/requests_/instrument.py
+++ b/signalfx_tracing/libraries/requests_/instrument.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from wrapt import wrap_function_wrapper
+import opentracing
+
+from signalfx_tracing import utils
+
+
+# Configures Requests tracing as described by
+# https://github.com/signalfx/python-requests/blob/master/README.rst
+config = utils.Config(
+    propagate=False,
+    span_tags=None,
+    tracer=None,
+)
+
+
+_session_new = [None]
+_session_tracing_new = [None]
+
+
+def session_new(_, __, *args, **kwargs):
+    """Monkey patch Session.__new__() to create a SessionTracing object"""
+    from requests_opentracing import SessionTracing
+    return SessionTracing.__new__(SessionTracing, *args, **kwargs)
+
+
+def session_tracing_new(_, __, *args, **kwargs):
+    """Monkey patch a valid SessionTracing.__new__() to avoid recursion on patched base class"""
+    from requests_opentracing import SessionTracing
+    return object.__new__(SessionTracing, *args, **kwargs)
+
+
+def instrument(tracer=None):
+    """
+    Requests auto-instrumentation works by hooking a __new__ proxy for a SessionTracing
+    instance upon requests.sessions.Session initialization to trigger proper inheritance.
+    SessionTracing.__init__ is also wrapped for correct argument injection.
+    """
+
+    requests = utils.get_module('requests')
+    if utils.is_instrumented(requests):
+        return
+
+    def session_tracing_init(__init__, instance, _, __):
+        _tracer = tracer or config.tracer or opentracing.tracer
+        __init__(_tracer, propagate=config.propagate, span_tags=config.span_tags or {})
+
+    from requests_opentracing import SessionTracing
+
+    _session_new[0] = requests.Session.__new__
+    _session_tracing_new[0] = SessionTracing.__new__
+
+    SessionTracing.__new__ = session_tracing_new.__get__(SessionTracing)
+    requests.Session.__new__ = session_new.__get__(requests.Session)
+    wrap_function_wrapper('requests_opentracing.tracing', 'SessionTracing.__init__', session_tracing_init)
+
+    utils.mark_instrumented(requests)
+
+
+def uninstrument():
+    requests = utils.get_module('requests')
+    if not utils.is_instrumented(requests):
+        return
+
+    from requests_opentracing import SessionTracing
+
+    if _session_tracing_new[0] is not None:
+        if hasattr(_session_tracing_new[0], '__get__'):
+            SessionTracing.__new__ = _session_tracing_new[0].__get__(SessionTracing)
+        else:  # builtin doesn't follow descriptor protocol
+            SessionTracing.__new__ = _session_tracing_new[0]
+    if _session_new[0] is not None:
+        if hasattr(_session_new[0], '__get__'):
+            requests.Session.__new__ = _session_new[0].__get__(requests.Session)
+        else:
+            requests.Session.__new__ = _session_new[0]
+
+    utils.revert_wrapper('requests_opentracing.tracing', 'SessionTracing.__init__')
+    utils.mark_uninstrumented(requests)

--- a/signalfx_tracing/libraries/tornado_/instrument.py
+++ b/signalfx_tracing/libraries/tornado_/instrument.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
-from tornado_opentracing.initialization import _unpatch_tornado, _unpatch_tornado_client
 from wrapt import wrap_function_wrapper
-import tornado_opentracing
 import opentracing
 
 from signalfx_tracing import utils
@@ -22,6 +20,8 @@ def instrument(tracer=None):
     tornado = utils.get_module('tornado')
     if utils.is_instrumented(tornado):
         return
+
+    tornado_opentracing = utils.get_module('tornado_opentracing')
 
     def _tracer_config(wrapped_tracer_config, _, wrapt_args, __):
         """
@@ -52,6 +52,9 @@ def uninstrument():
     tornado = utils.get_module('tornado')
     if not utils.is_instrumented(tornado):
         return
-    _unpatch_tornado()
-    _unpatch_tornado_client()
+
+    tornado_initialization = utils.get_module('tornado_opentracing.initialization')
+    tornado_initialization._unpatch_tornado()
+    tornado_initialization._unpatch_tornado_client()
+
     utils.mark_uninstrumented(tornado)

--- a/tests/integration/flask_/test_instrumented_app.py
+++ b/tests/integration/flask_/test_instrumented_app.py
@@ -9,7 +9,7 @@ import pytest
 import six
 
 from signalfx_tracing.libraries import flask_config
-from signalfx_tracing import auto_instrument
+from signalfx_tracing import instrument
 
 
 app_endpoint = 'http://127.0.0.1:32321/hello/MyName'
@@ -37,7 +37,7 @@ class TestFlaskApp(object):
 
         flask_config.traced_attributes = ['path', 'method', 'query_string', 'blueprint']
 
-        auto_instrument(tracer)
+        instrument(tracer, flask=True)
 
         from .app import app
         cls._app_store[0] = app

--- a/tests/integration/requests_/__init__.py
+++ b/tests/integration/requests_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/integration/requests_/test_instrumented_session.py
+++ b/tests/integration/requests_/test_instrumented_session.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from opentracing.mocktracer import MockTracer
+from opentracing.ext import tags as ext_tags
+from requests.sessions import Session
+import requests
+import docker
+import pytest
+
+from signalfx_tracing.libraries import requests_config as config
+from signalfx_tracing import instrument, uninstrument
+
+
+server_port = 5678
+server = 'http://localhost:{}'.format(server_port)
+
+
+@pytest.fixture(scope='session')
+def echo_container():
+    session = docker.from_env()
+    echo = session.containers.run('hashicorp/http-echo:latest', '-text="hello world"',
+                                  ports={'5678/tcp': server_port}, detach=True)
+    try:
+        yield echo
+    finally:
+        echo.remove(force=True, v=True)
+
+
+class TestSessionTracing(object):
+
+    @pytest.fixture
+    def session_tracing(self, echo_container):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.propagate = True
+        config.span_tags = dict(custom='tag')
+
+        instrument(requests=True)
+        try:
+            yield tracer
+        finally:
+            uninstrument('requests')
+
+    @pytest.fixture
+    def tracer(self, session_tracing):
+        return session_tracing
+
+    @pytest.fixture
+    def top_level_session(self, session_tracing):
+        return requests.Session()
+
+    @pytest.fixture
+    def session(self, session_tracing):
+        return Session()
+
+    @pytest.mark.parametrize('method', ('get', 'post', 'put', 'patch',
+                                        'head', 'delete', 'options'))
+    def test_successful_top_level_session_requests(self, tracer, top_level_session, method):
+        with tracer.start_active_span('root'):
+            response = getattr(top_level_session, method)(server)
+        request = response.request
+        spans = tracer.finished_spans()
+        assert len(spans) == 2
+        req_span, root_span = spans
+        assert req_span.operation_name == 'requests.{}'.format(method)
+
+        tags = req_span.tags
+        assert tags['custom'] == 'tag'
+        assert tags[ext_tags.COMPONENT] == 'requests'
+        assert tags[ext_tags.SPAN_KIND] == ext_tags.SPAN_KIND_RPC_CLIENT
+        assert tags[ext_tags.HTTP_STATUS_CODE] == 200
+        assert tags[ext_tags.HTTP_METHOD] == method
+        assert tags[ext_tags.HTTP_URL] == server
+        assert ext_tags.ERROR not in tags
+
+        assert request.headers['ot-tracer-spanid'] == '{0:x}'.format(req_span.context.span_id)
+        assert request.headers['ot-tracer-traceid'] == '{0:x}'.format(req_span.context.trace_id)
+
+    @pytest.mark.parametrize('method', ('get', 'post', 'put', 'patch',
+                                        'head', 'delete', 'options'))
+    def test_successful_session_requests(self, tracer, session, method):
+        with tracer.start_active_span('root'):
+            getattr(session, method)(server)
+        spans = tracer.finished_spans()
+        assert len(spans) == 2
+
+    @pytest.mark.parametrize('method', ('get', 'post', 'put', 'patch',
+                                        'head', 'delete', 'options'))
+    def test_successful_requests(self, tracer, method):
+        with tracer.start_active_span('root'):
+            getattr(requests, method)(server)
+        spans = tracer.finished_spans()
+        assert len(spans) == 2

--- a/tests/integration/tornado_/test_instrumented_app.py
+++ b/tests/integration/tornado_/test_instrumented_app.py
@@ -10,7 +10,7 @@ import pytest
 import six
 
 from signalfx_tracing.libraries import tornado_config
-from signalfx_tracing import auto_instrument
+from signalfx_tracing import instrument
 from .app import MyApplication, HelloHandler
 
 
@@ -43,7 +43,7 @@ class TestTornadoApp(object):
         tornado_config.start_span_cb = span_callback
         tornado_config.traced_attributes = ['path', 'method', 'query']
 
-        auto_instrument(tracer)
+        instrument(tracer, tornado=True)
 
         cls._app_store[0] = MyApplication([(r'/hello/(.*)', HelloHandler)])
         app_thread = Thread(target=cls.run_app)

--- a/tests/unit/libraries/requests_/__init__.py
+++ b/tests/unit/libraries/requests_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/unit/libraries/requests_/conftest.py
+++ b/tests/unit/libraries/requests_/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import pytest
+
+from signalfx_tracing.libraries.requests_.instrument import config, uninstrument
+
+
+class RequestsTestSuite(object):
+
+    @pytest.fixture(autouse=True)
+    def restored_requests_config(self):
+        orig = dict(config.__dict__)
+        yield
+        config.__dict__ = orig
+
+    @pytest.fixture(autouse=True)
+    def uninstrument_requests(self):
+        yield
+        uninstrument()

--- a/tests/unit/libraries/requests_/test_requests.py
+++ b/tests/unit/libraries/requests_/test_requests.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from opentracing.mocktracer import MockTracer
+import opentracing
+import requests
+import mock
+
+from signalfx_tracing.libraries.requests_.instrument import config, instrument, uninstrument
+from .conftest import RequestsTestSuite
+
+
+class MockResponse(object):
+
+    def __init__(self, method, url, headers=None):
+        self.method = method
+        self.url = url
+        self.status_code = 200
+        self.headers = headers or {}
+
+
+def mocked_request(self, method, url, *args, **kwargs):
+    return MockResponse(method, url, kwargs.get('headers'))
+
+
+class TestRequestsConfig(RequestsTestSuite):
+
+    def test_global_tracer_used_by_default(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+
+        instrument()
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'requests.get'
+
+    def test_tracer_is_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        instrument()
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'requests.get'
+
+    def test_propagate_is_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        instrument()
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            response = session.get('some_url')
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert 'ot-trace-spanid' not in response.headers
+        assert 'ot-trace-traceid' not in response.headers
+
+        tracer.reset()
+        config.propagate = True
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            response = session.get('some_url')
+        spans = tracer.finished_spans()
+
+        assert len(spans) == 1
+        span = spans[0]
+        assert response.headers['ot-tracer-spanid'] == '{0:x}'.format(span.context.span_id)
+        assert response.headers['ot-tracer-traceid'] == '{0:x}'.format(span.context.trace_id)
+
+    def test_span_tags_are_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.span_tags = dict(some='tag')
+
+        instrument()
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].tags['some'] == 'tag'
+
+
+class TestRequests(RequestsTestSuite):
+
+    def test_noninstrumented_client_does_not_trace(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        assert not tracer.finished_spans()
+
+    def test_uninstrumented_clients_no_longer_traces(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        instrument(tracer)
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'requests.get'
+
+        uninstrument()
+        tracer.reset()
+
+        session = requests.Session()
+        with mock.patch.object(requests.Session, 'request', mocked_request):
+            session.get('some_url')
+
+        assert not tracer.finished_spans()

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -22,8 +22,8 @@ else:
             yield
 
 
-expected_traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'tornado')
-expected_auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'tornado')
+expected_traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'requests', 'tornado')
+expected_auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'requests', 'tornado')
 
 
 class TestInstrument(object):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist=
     py{27,34,35,36}-pymysql{08,09}
     py{27,34,35,36}-jaeger
     py{27,34,35,36}-pymongo{31,32,33,34,35,36,37}
+    py{27,34,35,36}-requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}
 
 [testenv]
 basepython =
@@ -53,6 +54,27 @@ deps =
     pymongo37: pymongo>=3.7,<3.8
     pymongo{31,32,33,34,35,36,37}: docker
     pymongo{31,32,33,34,35,36,37}: mockupdb
+    requests20: requests>=2.0,<2.1
+    requests21: requests>=2.1,<2.2
+    requests22: requests>=2.2,<2.3
+    requests23: requests>=2.3,<2.4
+    requests24: requests>=2.4,<2.5
+    requests25: requests>=2.5,<2.6
+    requests26: requests>=2.6,<2.7
+    requests27: requests>=2.7,<2.8
+    requests28: requests>=2.8,<2.9
+    requests29: requests>=2.9,<2.10
+    requests210: requests>=2.10,<2.11
+    requests211: requests>=2.11,<2.12
+    requests212: requests>=2.12,<2.13
+    requests213: requests>=2.13,<2.14
+    requests214: requests>=2.14,<2.15
+    requests215: requests>=2.15,<2.16
+    requests216: requests>=2.16,<2.17
+    requests217: requests>=2.17,<2.18
+    requests218: requests>=2.18,<2.19
+    requests219: requests>=2.19,<2.20
+    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: docker
 
 commands = 
     flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
@@ -67,6 +89,8 @@ commands =
     pymongo{31,32,33,34,35,36,37}: pytest tests/unit/libraries/pymongo_
     pymysql{08,09}: pytest tests/integration/pymysql_
     pymysql{08,09}: pytest tests/unit/libraries/pymysql_
+    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: pytest tests/integration/requests_
+    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: pytest tests/unit/libraries/requests_
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
     tornado{43,44,45,50,51}: pytest tests/unit/libraries/tornado_
 


### PR DESCRIPTION
Provides auto-instrumenter (function wrapper and object creation hook) and test coverage for https://github.com/signalfx/python-requests.

Also includes lazy instrumenter loading and instrument() bug fix for missing library.