### PR TITLE
Initial Redis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ uninstrument(flask=False)  # prevent future registrations and
 * [Flask](./signalfx_tracing/libraries/flask_/README.md) - `instrument(flask=True)`
 * [PyMongo](./signalfx_tracing/libraries/pymongo_/README.md) - `instrument(pymongo=True)`
 * [PyMySQL](./signalfx_tracing/libraries/pymysql_/README.md) - `instrument(pymysql=True)`
+* [Redis-Py](./signalfx_tracing/libraries/redis_/README.md) - `instrument(redis=True)`
 * [Requests](./signalfx_tracing/libraries/requests_/README.md) - `instrument(requests=True)`
 * [Tornado](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -20,6 +20,7 @@ instrumenters = {
     'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
     'pymongo': 'git+ssh://git@github.com/signalfx/python-pymongo.git#egg=pymongo-opentracing',
     'pymysql': 'git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing',
+    'redis': 'https://github.com/signalfx/python-redis/tarball/ot_v2.0#egg=redis-opentracing',
     'requests': 'git+ssh://git@github.com/signalfx/python-requests.git#egg=requests-opentracing',
     'tornado': 'tornado_opentracing',
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,5 +8,6 @@ pymongo
 pymysql
 pytest
 pytest-django
+redis
 requests
 tornado

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ https://github.com/signalfx/python-flask/tarball/use_flask_scope_manager#egg=fla
 https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing
 git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing
 git+ssh://git@github.com/signalfx/python-pymongo.git#egg=pymongo-opentracing
+https://github.com/signalfx/python-redis/tarball/ot_v2.0#egg=redis-opentracing
 git+ssh://git@github.com/signalfx/python-requests.git#egg=requests-opentracing
 tornado_opentracing
 wrapt

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,11 @@ setup(name='signalfx-tracing',
           'Programming Language :: Python :: 3.6',
       ],
       packages=find_packages(),
-      install_requires=['wrapt'])
+      install_requires=['wrapt'],
+      extras_require={
+          'tests': [
+              'docker',
+              'mock',
+              'pytest',
+          ],
+      })

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 
 instrumented_attr = '__sfx_instrumented'
-traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'requests', 'tornado')
-auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'requests', 'tornado')
+traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
+auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')

--- a/signalfx_tracing/libraries/__init__.py
+++ b/signalfx_tracing/libraries/__init__.py
@@ -3,5 +3,6 @@ from .django_ import config as django_config  # noqa
 from .flask_ import config as flask_config  # noqa
 from .pymongo_ import config as pymongo_config  # noqa
 from .pymysql_ import config as pymysql_config  # noqa
+from .redis_ import config as redis_config # noqa
 from .requests_ import config as requests_config # noqa
 from .tornado_ import config as tornado_config  # noqa

--- a/signalfx_tracing/libraries/flask_/README.md
+++ b/signalfx_tracing/libraries/flask_/README.md
@@ -31,14 +31,13 @@ import flask
 # instrument(flask=True)  # or sfx_tracing.auto_instrument()
 # instrumented_app = flask.Flask(...)
 #
-# Accessing Flask from its parent flask module object requires no advanced instrumentation
-# beyond that of pre-initialization.  If you are importing Flask from flask directly, you
-# must instrument before doing so:
+# Importing Flask from its parent flask module object requires no advanced instrumentation
+# beyond that of pre-initialization:
 #
 # from sfx_tracing import instrument
-# instrument(flask=True)  # or sfx_tracing.auto_instrument()
-#
 # from flask import Flask
+#
+# instrument(flask=True)  # or sfx_tracing.auto_instrument()
 # instrumented_app = Flask(...)
 # ***
 

--- a/signalfx_tracing/libraries/pymongo_/README.md
+++ b/signalfx_tracing/libraries/pymongo_/README.md
@@ -29,14 +29,13 @@ import pymongo
 # instrument(pymongo=True)  # or sfx_tracing.auto_instrument()
 # traced_client = pymongo.MongoClient(...)
 #
-# Accessing MongoClient from its parent pymongo module object requires no advanced instrumentation
-# beyond that of pre-initialization.  If you are importing MongoClient from pymongo directly, you
-# must instrument before doing so:
+# Importing MongoClient from its parent pymongo module object requires no advanced instrumentation
+# beyond that of pre-initialization:
 #
 # from sfx_tracing import instrument
-# instrument(pymongo=True)  # or sfx_tracing.auto_instrument()
-#
 # from pymongo import MongoClient
+#
+# instrument(pymongo=True)  # or sfx_tracing.auto_instrument()
 # traced_client = MongoClient(...)
 # ***
 

--- a/signalfx_tracing/libraries/redis_/README.md
+++ b/signalfx_tracing/libraries/redis_/README.md
@@ -1,0 +1,59 @@
+# Redis
+
+- [opentracing-contrib/python-redis](https://github.com/opentracing-contrib/python-redis)
+- [Official Site](https://redis.io/)
+
+The SignalFx Auto-instrumenter configures the OpenTracing Redis-Py instrumentation for your 2.10+ `StrictRedis`
+client commands.  You can enable instrumentation within your client, pipeline, and PubSub commands by invoking
+the `signalfx_tracing.auto_instrument()` function before initializing your `StrictRedis` object.
+To configure tracing, some tunables are provided via `redis_config` to establish the desired tracer and
+custom operation name prefixes for all created spans:
+
+| Setting name | Definition | Default value |
+| -------------|------------|---------------|
+| operation_prefix | String prefix to prepend to all spans' operation names. | `"Redis"` |
+| tracer | An instance of an OpenTracing-compatible tracer for all Redis traces. | `opentracing.tracer` |
+
+```python
+# my_app.py
+from signalfx_tracing import auto_instrument, instrument
+from signalfx_tracing.libraries import redis_config 
+
+import redis
+
+# ***
+# The SignalFx Redis Auto-instrumenter works by monkey patching the StrictRedis.__init__() method.
+# You must invoke auto_instrument() or instrument() before instantiating your client. 
+#
+# from sfx_tracing import instrument
+# instrument(redis=True)  # or sfx_tracing.auto_instrument()
+# traced_client = redis.StrictRedis(...)
+#
+# Importing StrictRedis from its parent redis package or redis.client module objects requires no advanced
+# instrumentation beyond that of pre-initialization:
+#
+# from sfx_tracing import instrument
+# from redis import StrictRedis
+#
+# instrument(redis=True)  # or sfx_tracing.auto_instrument()
+# traced_client = StrictRedis(...)
+# ***
+
+redis_config.operation_prefix = 'MyOperationalZone'
+redis_config.tracer = MyTracer()
+
+auto_instrument()  # or instrument(redis=True)
+
+# All new instances of StrictClients will have their executed commands traced
+traced_client = redis.StrictRedis(...)
+traced_set_response = traced_client.set('my_key', 'my_value')
+
+another_traced_client = redis.StrictRedis(...)
+traced_pubsub = another_traced_client.pubsub(...)
+traced_pubsub.subscribe('MyChannel')
+
+traced_pipeline = traced_client.pipeline()
+traced_pipeline.set('some_key', 'some_value')
+traced_pipeline.set('some_other_key', 'some_other_value')
+traced_pipeline.execute()
+```

--- a/signalfx_tracing/libraries/redis_/__init__.py
+++ b/signalfx_tracing/libraries/redis_/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from .instrument import config, instrument, uninstrument  # noqa

--- a/signalfx_tracing/libraries/redis_/instrument.py
+++ b/signalfx_tracing/libraries/redis_/instrument.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from wrapt import wrap_function_wrapper
+import opentracing
+
+from signalfx_tracing import utils
+
+
+# Configures Redis tracing as described by
+# https://github.com/opentracing-contrib/python-redis/blob/master/README.rst
+config = utils.Config(
+    operation_prefix='Redis',
+    tracer=None,
+)
+
+
+def instrument(tracer=None):
+    redis = utils.get_module('redis')
+    if utils.is_instrumented(redis):
+        return
+
+    redis_opentracing = utils.get_module('redis_opentracing')
+    redis_opentracing.init_tracing(tracer=tracer or config.tracer or opentracing.tracer,
+                                   trace_all_classes=False,
+                                   prefix=config.operation_prefix)
+
+    def traced_client(__init__, client, args, kwargs):
+        __init__(*args, **kwargs)
+        redis_opentracing.trace_client(client)
+
+    wrap_function_wrapper('redis.client', 'StrictRedis.__init__', traced_client)
+    utils.mark_instrumented(redis)
+
+
+def uninstrument():
+    """Will only prevent new clients from registering tracers."""
+    redis = utils.get_module('redis')
+    if not utils.is_instrumented(redis):
+        return
+
+    from redis.client import StrictRedis
+    utils.revert_wrapper(StrictRedis, '__init__')
+    utils.mark_uninstrumented(redis)

--- a/tests/integration/redis_/__init__.py
+++ b/tests/integration/redis_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/integration/redis_/test_instrumented_client.py
+++ b/tests/integration/redis_/test_instrumented_client.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from opentracing.mocktracer import MockTracer
+from opentracing.ext import tags as ext_tags
+import docker
+import pytest
+from redis import StrictRedis
+
+from signalfx_tracing.libraries import redis_config as config
+from signalfx_tracing import instrument, uninstrument
+
+
+@pytest.fixture(scope='session')
+def redis_container():
+    session = docker.from_env()
+    redis = session.containers.run('redis:latest', ports={'6379/tcp': 6379}, detach=True)
+    try:
+        yield redis
+    finally:
+        redis.remove(force=True, v=True)
+
+
+class TestClientTracing(object):
+
+    @pytest.fixture
+    def client_tracing(self, redis_container):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.operation_prefix = 'MyPrefix'
+
+        instrument(redis=True)
+        try:
+            yield tracer
+        finally:
+            uninstrument('redis')
+
+    @pytest.fixture
+    def tracer(self, client_tracing):
+        return client_tracing
+
+    @pytest.fixture
+    def client(self, client_tracing):
+        return StrictRedis()
+
+    def test_successfully_traced_command(self, tracer, client):
+        with tracer.start_active_span('root'):
+            client.set('key', 'val')
+        spans = tracer.finished_spans()
+        assert len(spans) == 2
+        req_span, root_span = spans
+        assert req_span.operation_name == 'MyPrefix/SET'
+
+        tags = req_span.tags
+        assert tags[ext_tags.COMPONENT] == 'redis-py'
+        assert tags[ext_tags.SPAN_KIND] == ext_tags.SPAN_KIND_RPC_CLIENT
+        assert tags[ext_tags.DATABASE_TYPE] == 'redis'
+        assert tags[ext_tags.DATABASE_STATEMENT] == 'SET key val'
+        assert ext_tags.ERROR not in tags
+
+    def test_successfully_traced_pubsub(self, tracer, client):
+        with tracer.start_active_span('root'):
+            pubsub = client.pubsub()
+            pubsub.subscribe('myChannel')
+            client.publish('myChannel', 'hey')
+            pubsub.parse_response()
+            pubsub.unsubscribe('myChannel')
+
+            pubsub = client.pubsub()
+            pubsub.subscribe('myOtherChannel')
+            client.publish('myOtherChannel', 'hey')
+            pubsub.parse_response()
+            pubsub.unsubscribe('myOtherChannel')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 9
+
+    def test_successfully_traced_pipeline(self, tracer, client):
+        with tracer.start_active_span('root'):
+            pipeline = client.pipeline()
+            pipeline.set('key', 'value')
+            pipeline.get('key')
+            pipeline.execute()
+
+            pipeline = client.pipeline()
+            pipeline.set('another_key', 'value')
+            pipeline.get('another_key')
+            pipeline.execute()
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 3

--- a/tests/unit/libraries/flask_/test_flask.py
+++ b/tests/unit/libraries/flask_/test_flask.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 from opentracing.mocktracer import MockTracer
 from flask_opentracing import FlaskTracer
+from flask import Flask
 import opentracing
 import pytest
-import flask
 
 from signalfx_tracing.libraries.flask_ import config, instrument, uninstrument
 from .conftest import FlaskTestSuite
@@ -19,7 +19,7 @@ class TestFlaskConfig(FlaskTestSuite):
         # config.traced_attributes adoption is not exposed
 
         instrument()
-        app = flask.Flask('MyFlaskApplication')
+        app = Flask('MyFlaskApplication')
 
         flask_tracer = app.config['FLASK_TRACER']
         assert isinstance(flask_tracer, FlaskTracer)
@@ -35,7 +35,7 @@ class TestFlaskConfig(FlaskTestSuite):
 class TestFlaskApplication(FlaskTestSuite):
 
     def make_app(self):
-        app = flask.Flask('MyFlaskApplication')
+        app = Flask('MyFlaskApplication')
 
         @app.route('/')
         def my_route():

--- a/tests/unit/libraries/redis_/__init__.py
+++ b/tests/unit/libraries/redis_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/tests/unit/libraries/redis_/conftest.py
+++ b/tests/unit/libraries/redis_/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import pytest
+
+from signalfx_tracing.libraries.redis_.instrument import config, uninstrument
+
+
+class RedisTestSuite(object):
+
+    @pytest.fixture(autouse=True)
+    def restored_redis_config(self):
+        orig = dict(config.__dict__)
+        yield
+        config.__dict__ = orig
+
+    @pytest.fixture(autouse=True)
+    def uninstrument_redis(self):
+        yield
+        uninstrument()

--- a/tests/unit/libraries/redis_/test_redis.py
+++ b/tests/unit/libraries/redis_/test_redis.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from opentracing.mocktracer import MockTracer
+import opentracing
+import redis
+import mock
+
+from signalfx_tracing.libraries.redis_.instrument import config, instrument, uninstrument
+from .conftest import RedisTestSuite
+
+
+def mock_execute_command(*args, **kwargs):
+    return True
+
+
+class TestRedisConfig(RedisTestSuite):
+
+    def test_global_tracer_used_by_default(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            instrument()
+            client = redis.StrictRedis()
+            client.set('key', 'value')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'Redis/SET'
+
+    def test_tracer_is_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            instrument()
+            client = redis.StrictRedis()
+            client.get('key')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'Redis/GET'
+
+    def test_prefix_is_sourced(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.operation_prefix = 'MyPrefix'
+
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            instrument()
+            client = redis.StrictRedis()
+            client.move('key', 'db')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'MyPrefix/MOVE'
+
+
+class TestRedis(RedisTestSuite):
+
+    def test_noninstrumented_client_does_not_trace(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        client = redis.StrictRedis()
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            client.get('some_url')
+
+        assert not tracer.finished_spans()
+
+    def test_uninstrumented_clients_no_longer_traces(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        config.tracer = tracer
+
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            instrument(tracer)
+            client = redis.StrictRedis()
+            client.get('some_url')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].operation_name == 'Redis/GET'
+
+        uninstrument()
+        tracer.reset()
+
+        client = redis.StrictRedis()
+        with mock.patch.object(redis.StrictRedis, 'execute_command', mock_execute_command):
+            client.get('some_url')
+
+        assert not tracer.finished_spans()

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -22,8 +22,8 @@ else:
             yield
 
 
-expected_traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'requests', 'tornado')
-expected_auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'requests', 'tornado')
+expected_traceable_libraries = ('django', 'flask', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
+expected_auto_instrumentable_libraries = ('flask', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
 
 
 class TestInstrument(object):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist=
     py{27,34,35,36}-pymysql{08,09}
     py{27,34,35,36}-jaeger
     py{27,34,35,36}-pymongo{31,32,33,34,35,36,37}
+    py{27,34,35,36}-redis210
     py{27,34,35,36}-requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}
 
 [testenv]
@@ -24,27 +25,18 @@ deps =
     py{27,34,35,36}: pytest
     py{27,34,35,36}: mock
     py{27,34,35,36}: -rrequirements.txt
-    django18: django>=1.8,<1.9
-    django19: django>=1.9,<1.10
     django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
+    django18: django>=1.8,<1.9
+    django19: django>=1.9,<1.10
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django{18,19,110,111,20,21}: pytest-django
-    tornado43: tornado>=4.3,<4.4
-    tornado44: tornado>=4.4,<4.5
-    tornado45: tornado>=4.5,<5.0
-    tornado50: tornado>=5.0,<5.1
-    tornado51: tornado>=5.1,<5.2
-    tornado{43,44,45,50,51}: requests
     flask010: flask>=0.10,<0.11
     flask011: flask>=0.11,<0.12
     flask012: flask>=0.12,<0.13
     flask10: flask>=1.0,<1.1
     flask{010,011,012,10}: requests
-    pymysql08: pymysql>=0.8,<0.9
-    pymysql09: pymysql>=0.9,<1.0
-    pymysql{08,09}: docker
     pymongo31: pymongo>=3.1,<3.2
     pymongo32: pymongo>=3.2,<3.3
     pymongo33: pymongo>=3.3,<3.4
@@ -54,16 +46,12 @@ deps =
     pymongo37: pymongo>=3.7,<3.8
     pymongo{31,32,33,34,35,36,37}: docker
     pymongo{31,32,33,34,35,36,37}: mockupdb
+    pymysql08: pymysql>=0.8,<0.9
+    pymysql09: pymysql>=0.9,<1.0
+    pymysql{08,09}: docker
+    redis210: redis>=2.10,<2.11
+    redis210: docker
     requests20: requests>=2.0,<2.1
-    requests21: requests>=2.1,<2.2
-    requests22: requests>=2.2,<2.3
-    requests23: requests>=2.3,<2.4
-    requests24: requests>=2.4,<2.5
-    requests25: requests>=2.5,<2.6
-    requests26: requests>=2.6,<2.7
-    requests27: requests>=2.7,<2.8
-    requests28: requests>=2.8,<2.9
-    requests29: requests>=2.9,<2.10
     requests210: requests>=2.10,<2.11
     requests211: requests>=2.11,<2.12
     requests212: requests>=2.12,<2.13
@@ -74,7 +62,22 @@ deps =
     requests217: requests>=2.17,<2.18
     requests218: requests>=2.18,<2.19
     requests219: requests>=2.19,<2.20
+    requests21: requests>=2.1,<2.2
+    requests22: requests>=2.2,<2.3
+    requests23: requests>=2.3,<2.4
+    requests24: requests>=2.4,<2.5
+    requests25: requests>=2.5,<2.6
+    requests26: requests>=2.6,<2.7
+    requests27: requests>=2.7,<2.8
+    requests28: requests>=2.8,<2.9
+    requests29: requests>=2.9,<2.10
     requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: docker
+    tornado43: tornado>=4.3,<4.4
+    tornado44: tornado>=4.4,<4.5
+    tornado45: tornado>=4.5,<5.0
+    tornado50: tornado>=5.0,<5.1
+    tornado51: tornado>=5.1,<5.2
+    tornado{43,44,45,50,51}: requests
 
 commands = 
     flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
@@ -89,6 +92,8 @@ commands =
     pymongo{31,32,33,34,35,36,37}: pytest tests/unit/libraries/pymongo_
     pymysql{08,09}: pytest tests/integration/pymysql_
     pymysql{08,09}: pytest tests/unit/libraries/pymysql_
+    redis210: pytest tests/integration/redis_
+    redis210: pytest tests/unit/libraries/redis_
     requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: pytest tests/integration/requests_
     requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219}: pytest tests/unit/libraries/requests_
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_


### PR DESCRIPTION
Provides auto-instrumenter (function wrapper) and test coverage for https://github.com/signalfx/python-redis.

Also corrects some unrelated library importing guidelines.