### PR TITLE
Update readme and sane create_tracer defaults

### DIFF
--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -51,8 +51,9 @@ def revert_wrapper(obj, wrapped_attr):
 
 def create_tracer(access_token=None, set_global=True, config=None, *args, **kwargs):
     """
-    Creates a jaeger_client.Tracer via Config().initialization_tracer.
-    Default config argument will consist only of service name of 'SignalFx-Tracing' value.
+    Creates a jaeger_client.Tracer via Config().initialize_tracer().
+    Default config argument will consist of service name of 'SignalFx-Tracing' value,
+    B3 span propagation, and a ConstSampler.
     """
     access_token = access_token or os.environ.get('SIGNALFX_ACCESS_TOKEN')
     if not access_token:
@@ -67,6 +68,10 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
         config['jaeger_user'] = 'auth'
     if 'jaeger_password' not in config:
         config['jaeger_password'] = access_token
+    if 'sampler' not in config:
+        config['sampler'] = dict(type='const', param=1)
+    if 'propagation' not in config:
+        config['propagation'] = 'b3'
     jaeger_config = Config(config, *args, **kwargs)
 
     tracer = jaeger_config.initialize_tracer()

--- a/tests/integration/flask_/app.py
+++ b/tests/integration/flask_/app.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+import opentracing
 import flask
 
 
@@ -7,6 +8,8 @@ app = flask.Flask('MyFlaskApplication')
 
 @app.route('/hello/<username>', methods=['GET', 'POST', 'PATCH', 'PUT', 'DELETE'])
 def my_route(username):
+    span = opentracing.tracer.scope_manager.active.span
+    span.set_tag('handled', 'tag')
     return 'Hello, {}!'.format(username)
 
 
@@ -15,6 +18,8 @@ bp = flask.Blueprint('MyBlueprint', 'MyFlaskApplication')
 
 @bp.route('/<page>', methods=['GET', 'POST', 'PATCH', 'PUT', 'DELETE'])
 def my_blueprint_route(page):
+    span = opentracing.tracer.scope_manager.active.span
+    span.set_tag('handled', 'tag')
     return 'Rendering {}'.format(page)
 
 


### PR DESCRIPTION
Removes the basic installation procedure, provides active span manipulation example, and creates a more real-world tracer configuration.