### PR TITLE
Add sfx-py-trace utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,32 @@ tracer = create_tracer(
     scope_manager=TornadoScopeManager  # Necessary for span scope in Tornado applications
 )
 ```
+
+## Usage
+
+SignalFx-Tracing auto-instrumentation and its configuration can be performed while loading your
+framework-based and library-utilizing application as described in the corresponding
+[instrumentation instructions](#supported-frameworks-and-libraries).
+However, if you have installed the recommend Jaeger client (`./bootstrap.py --jaeger`) and would like to
+automatically instrument your applicable program with the default settings, a helpful `sfx-py-trace` entry point
+is provided by the installer:
+
+```sh
+ $ SIGNALFX_ACCESS_TOKEN=<MyAccessToken> sfx-py-trace my_application.py --app_arg_one --app_arg_two
+ # or
+ $ sfx-py-trace --token <MyAccessToken> my_application.py --app_arg_one --app_arg_two
+```
+
+**Note: `sfx-py-trace` cannot, at this time, enable auto-instrumentation of Django projects, as the instrumentor
+application must be added to the project settings' installed apps for lazy tracer creation.**
+
+This command line script loader will create a Jaeger tracer instance using the access token specified via
+environment variable or argument to report your spans to SignalFx.  It will then call `auto_instrument()` before
+running your target application file in its own module namespace.  It's important to note that due to potential
+deadlocks in importing forking code, a Jaeger tracer cannot be initialized as a side effect of an import statement
+(see: [Python threading doc](https://docs.python.org/2/library/threading.html#importing-in-threaded-code) and
+[known Jaeger issue](https://github.com/jaegertracing/jaeger-client-python/issues/60#issuecomment-318909730)).
+
+Because of this constraint, the `sfx-py-trace` utility is not a substitute for a system Python executable and
+must be provided a target Python script or path with `__main__` module.  There are plans to remove Jaeger's
+Tornado dependency that will remove this restriction in the future and allow expanded functionality.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,4 @@ pytest-django
 redis
 requests
 tornado
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ git+ssh://git@github.com/signalfx/python-dbapi.git#egg=dbapi-opentracing
 git+ssh://git@github.com/signalfx/python-pymongo.git#egg=pymongo-opentracing
 https://github.com/signalfx/python-redis/tarball/ot_v2.0#egg=redis-opentracing
 git+ssh://git@github.com/signalfx/python-requests.git#egg=requests-opentracing
+https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client
 tornado_opentracing
 wrapt

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.

--- a/scripts/sfx_py_trace.py
+++ b/scripts/sfx_py_trace.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from argparse import ArgumentParser, REMAINDER
+import runpy
+import sys
+import os
+
+from signalfx_tracing import auto_instrument, create_tracer
+
+ap = ArgumentParser()
+ap.add_argument('--token', '-t', required=False, type=str, dest='token',
+                help='Your SignalFx Access Token (SIGNALFX_ACCESS_TOKEN env var by default)')
+ap.add_argument('target', help='Your Python application.')
+ap.add_argument('target_args', help='Arguments for your application.', nargs=REMAINDER)
+
+
+def main():
+    args = ap.parse_args()
+    access_token = args.token or os.environ.get('SIGNALFX_ACCESS_TOKEN')
+    if not access_token:
+        ap.error('You must provide --token or set "SIGNALFX_ACCESS_TOKEN" environment variable.')
+
+    auto_instrument(create_tracer(access_token=access_token, set_global=True))
+
+    sys.argv = [args.target] + args.target_args
+    runpy.run_path(args.target)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,11 @@ setup(name='signalfx-tracing',
               'docker',
               'mock',
               'pytest',
+              'six',
           ],
+      },
+      entry_points={
+          'console_scripts': [
+              'sfx-py-trace = scripts.sfx_py_trace:main'
+          ]
       })

--- a/signalfx_tracing/__init__.py
+++ b/signalfx_tracing/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 from .instrumentation import instrument, uninstrument, auto_instrument  # noqa
+from .utils import create_tracer  # noqa
 
 # Django
 default_app_config = 'signalfx_tracing.libraries.django_.apps.SignalFxConfig'  # noqa

--- a/tests/integration/lib/runner_target_script.py
+++ b/tests/integration/lib/runner_target_script.py
@@ -1,0 +1,37 @@
+from argparse import ArgumentParser
+import sys
+import os
+
+from jaeger_client import Tracer
+import opentracing
+
+
+assert isinstance(opentracing.tracer, Tracer)
+
+ap = ArgumentParser()
+ap.add_argument('--one', dest='one', type=int, required=True)
+ap.add_argument('--two', dest='two', type=float)
+ap.add_argument('--three', dest='three', type=str)
+ap.add_argument('-i', dest='i', type=int, nargs='+')
+ap.add_argument('-j', dest='j', type=int, nargs='+')
+
+# Test for sfx_py_tracing collisions
+ap.add_argument('-t', dest='t', type=str)
+ap.add_argument('--token', dest='token', type=str)
+
+known, unknown = ap.parse_known_args()
+
+assert known.one == 123
+assert known.two == 123.456
+assert known.three == 'This Is A String'
+assert known.i == [1, 2, 3, 4, 5]
+assert known.j == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+assert known.t == 'collision1'
+assert known.token == 'collision2'
+assert unknown == ['--unknown=asdf', '-u' 'file.py', 'file.txt']
+
+assert sys.argv == [os.path.abspath(__file__), '--one', '123', '--two', '123.456',
+                    '--three', 'This Is A String', '-i', '1', '2', '3', '4', '5',
+                    '-j', '1', '2', '3', '4', '5', '-t', 'collision1', '--token', 'collision2',
+                    '--unknown=asdf', '-u' 'file.py', 'file.txt']

--- a/tests/integration/test_runner.py
+++ b/tests/integration/test_runner.py
@@ -1,0 +1,69 @@
+from subprocess import check_output, CalledProcessError, STDOUT
+import os.path
+import os
+
+from six import text_type as tt
+import pytest
+
+
+target = os.path.join(os.path.dirname(__file__), 'lib/runner_target_script.py')
+target_args = ['--one', '123', '--two', '123.456', '--three', 'This Is A String',
+               '-i', '1', '2', '3', '4', '5', '-j', '1', '2', '3', '4', '5',
+               '-t', 'collision1', '--token', 'collision2', '--unknown=asdf',
+               '-u' 'file.py', 'file.txt']
+
+
+class TestRunner(object):
+
+    @pytest.fixture(scope='class', autouse=True)
+    def clear_token(self):
+        token = os.environ.pop('SIGNALFX_ACCESS_TOKEN', None)
+        yield
+        if token:
+            os.environ['SIGNALFX_ACCESS_TOKEN'] = token
+
+    def check_output(self, arg_ls, **kwargs):
+        return check_output(arg_ls, stderr=STDOUT, **kwargs)
+
+    def test_missing_token_arg(self):
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace', 'file.py'])
+        assert 'You must provide --token or set "SIGNALFX_ACCESS_TOKEN" environment variable.' in tt(e.value.output)
+
+    def test_env_var_missing_target(self):
+        env = dict(os.environ)
+        env['SIGNALFX_ACCESS_TOKEN'] = '123'
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace'], env=env)
+        output = tt(e.value.output)
+        assert ('too few arguments' in output or 'the following arguments are required: target' in output)
+
+    def test_flag_missing_target(self):
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace', '-t', '123'])
+        output = tt(e.value.output)
+        assert ('too few arguments' in output or 'the following arguments are required: target' in output)
+
+    def test_named_missing_target(self):
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace', '--token', '123'])
+        output = tt(e.value.output)
+        assert ('too few arguments' in output or 'the following arguments are required: target' in output)
+
+    def test_flag_missing_target_args(self):
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace', '-t', '123', target])
+        output = tt(e.value.output)
+        assert 'required' in output or '--one' in output
+
+    def test_flag_with_target_args(self):
+        self.check_output(['sfx-py-trace', '-t', '123', target] + target_args)
+
+    def test_named_missing_target_args(self):
+        with pytest.raises(CalledProcessError) as e:
+            self.check_output(['sfx-py-trace', '--token', '123', target])
+        output = tt(e.value.output)
+        assert 'required' in output or '--one' in output
+
+    def test_named_with_target_args(self):
+        self.check_output(['sfx-py-trace', '--token', '123', target] + target_args)

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ commands =
     flask{010,011,012,10}: pytest tests/unit/libraries/flask_
     jaeger: ./bootstrap.py --jaeger
     jaeger: pytest tests/integration/test_jaeger_client.py
+    jaeger: pytest tests/integration/test_runner.py
     pymongo{31,32,33,34,35,36,37}: pytest tests/integration/pymongo_
     pymongo{31,32,33,34,35,36,37}: pytest tests/unit/libraries/pymongo_
     pymysql{08,09}: pytest tests/integration/pymysql_


### PR DESCRIPTION
Provides and documents `sfx_py_tracing` script loader.  This is not a system python replacement due to Jaeger's Tornado dependency:  https://github.com/jaegertracing/jaeger-client-python/issues/60#issuecomment-318909730.

After the Tornado-ectomy, this should be updated to use the site module instead of runpy.

~~edit: WIP: currently adding more robust argument handling and help options.~~

edit 2: Broke out a target positional arg and added token env var integration test.

```
usage: sfx_py_tracing [-h] [--token TOKEN] target ...

positional arguments:
  target                Your Python application.
  target_args           Arguments for your application.

optional arguments:
  -h, --help            show this help message and exit
  --token TOKEN, -t TOKEN
                        Your SignalFx Access Token (SIGNALFX_ACCESS_TOKEN env
                        var by default)
```