### PR TITLE
Expand setup bootstrap functionality

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include requirements*.txt
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+recursive-exclude tests *

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ The SignalFx-Tracing Library for Python works by detecting your available librar
 instrumentors for distributed tracing via the Python
 [OpenTracing API 2.0](https://pypi.org/project/opentracing/2.0.0/).  As adoption of this API
 is done on a per-instrumentor basis, it's recommended that you use the helpful bootstrap
-utility for obtaining and installing feature-ready instrumentor versions:
+utility for obtaining and installing feature-ready instrumentor versions and a compatible tracer:
 
 ```sh
- $ ./bootstrap.py
+ $ pip install signalfx-tracing
+ $ sfx-py-trace-bootstrap
 ```
 
 For example, if your environment has Requests and Flask in its Python path, the corresponding OpenTracing
@@ -75,12 +76,14 @@ ubiquitous, this bootstrap selectively installs custom instrumentors listed in
 [the requirements file](./requirements.txt).  As such, we suggest being sure to uninstall any previous
 instrumentor versions before running the bootstrapper, ideally in a clean environment.
 
-Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide the option
-of, and highly recommend, installing a modified [Jaeger Client](https://github.com/jaegertracing/jaeger-client-python)
-ready for reporting to SignalFx:
+Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide
+and highly recommend installing a modified [Jaeger Client](https://github.com/jaegertracing/jaeger-client-python)
+ready for reporting to SignalFx.  This is done by default when running `sfx-py-trace-bootstrap`.  To
+run the instrumentor bootstrap process without installing our Jaeger fork, you can run:
 
 ```sh
- $ ./bootstrap.py --jaeger
+ $ pip install signalfx-tracing
+ $ scripts/bootstrap.py --deps-only
 ```
 
 You can obtain an instance of this tracer using the `signalfx_tracing.utils.create_tracer()` helper.  By default

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ def untraced_route():
 
 ## Installation and Configuration
 
-The SignalFx-Tracing Library for Python works by detecting your available libraries and frameworks and configuring
-instrumentors for distributed tracing via the Python
-[OpenTracing API 2.0](https://pypi.org/project/opentracing/2.0.0/).  As adoption of this API
-is done on a per-instrumentor basis, it's recommended that you use the helpful bootstrap
-utility for obtaining and installing feature-ready instrumentor versions and a compatible tracer:
+### Library and Instrumentors
+The SignalFx-Tracing Library for Python works by detecting your libraries and frameworks and configuring available
+instrumentors for distributed tracing via the Python [OpenTracing API 2.0](https://pypi.org/project/opentracing/2.0.0/). 
+By default, its footprint is small and doesn't declare any instrumentors as dependencies. That is, it operates on the
+assumption that you have 2.0-compatible instrumentors installed as needed. As adoption of this API is done on a
+per-instrumentor basis, it's highly recommended you use the helpful bootstrap utility for obtaining and installing any
+applicable, feature-ready instrumentors along with a compatible tracer:
 
 ```sh
  $ pip install signalfx-tracing
@@ -73,22 +75,47 @@ utility for obtaining and installing feature-ready instrumentor versions and a c
 For example, if your environment has Requests and Flask in its Python path, the corresponding OpenTracing
 instrumentors will be pip installed.  Again, since OpenTracing-Contrib instrumentation support of API 2.0 is not
 ubiquitous, this bootstrap selectively installs custom instrumentors listed in
-[the requirements file](./requirements.txt).  As such, we suggest being sure to uninstall any previous
+[the instrumentor requirements file](./requirements-inst.txt).  As such, we suggest being sure to uninstall any previous
 instrumentor versions before running the bootstrapper, ideally in a clean environment.
 
-Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide
-and highly recommend installing a modified [Jaeger Client](https://github.com/jaegertracing/jaeger-client-python)
-ready for reporting to SignalFx.  This is done by default when running `sfx-py-trace-bootstrap`.  To
-run the instrumentor bootstrap process without installing our Jaeger fork, you can run:
+To run the instrumentor bootstrap process without installing the suggested tracer, you can run the following from this
+project's source tree:
 
 ```sh
- $ pip install signalfx-tracing
  $ scripts/bootstrap.py --deps-only
 ```
 
-You can obtain an instance of this tracer using the `signalfx_tracing.utils.create_tracer()` helper.  By default
-it will enable tracing with constant sampling (100% chance of tracing) and report each span directly to SignalFx.
-Where applicable, context propagation will be done via [B3 headers](https://github.com/openzipkin/b3-propagation).
+It's also possible to install the supported instrumentors as package extras:
+
+```bash
+  # Supported extras are dbapi, django, flask, pymongo, pymysql, redis, requests, tornado
+  $ pip install --process-dependency-links 'signalfx-tracing[django,redis,requests]'
+```
+
+**Note: It's necessary to include `--process-dependency-links` to obtain the desired instrumentor versions.**
+
+### Tracer
+Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide
+and recommend installing a modified [Jaeger Client](https://github.com/jaegertracing/jaeger-client-python)
+ready for reporting to SignalFx. You can obtain an instance of the suggested Jaeger tracer using a
+ `signalfx_tracing.utils.create_tracer()` helper, provided you've run:
+
+```sh
+  $ sfx-py-trace-bootstrap
+
+  # or as package extra (please note required --process-dependency-links)
+  $ pip install --process-dependency-links 'signalfx-tracing[jaeger]'
+
+  # or from project source tree, along with applicable instrumentors
+  $ scripts/bootstrap.py --jaeger
+
+  # or to avoid applicable instrumentors
+  $ scripts/bootstrap.py --jaeger-only
+```
+
+By default `create_tracer()` will enable tracing with constant sampling (100% chance of tracing) and report each span
+directly to SignalFx. Where applicable, context propagation will be done via
+[B3 headers](https://github.com/openzipkin/b3-propagation).
 
 ```python
 from signalfx_tracing import create_tracer
@@ -96,7 +123,7 @@ from signalfx_tracing import create_tracer
 # sets the global opentracing.tracer by default:
 tracer = create_tracer()  # uses 'SIGNALFX_ACCESS_TOKEN' environment variable if provided
 
-# or directly provide your organization access token if not using the Smart Agent or Smart Gateway to analyze spans:
+# or directly provide your organization access token if not using the Smart Agent or Gateway to analyze spans:
 tracer = create_tracer('<OrganizationAccessToken>', ...)
 
 # or to disable setting the global tracer:
@@ -138,7 +165,7 @@ variables are checked for before selecting a default value:
 The SignalFx-Tracing Library for Python's auto-instrumentation configuration can be performed while loading
 your framework-based and library-utilizing application as described in the corresponding
 [instrumentation instructions](#supported-frameworks-and-libraries).
-However, if you have installed the recommend Jaeger client (`./bootstrap.py --jaeger`) and would like to
+However, if you have installed the recommended [Jaeger client](#Tracer) (`sfx-py-trace-bootstrap`) and would like to
 automatically instrument your applicable program with the default settings, a helpful `sfx-py-trace` entry point
 is provided by the installer:
 

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,0 +1,8 @@
+dbapi-opentracing
+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
+https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender#egg=jaeger-client
+pymongo-opentracing
+https://github.com/opentracing-contrib/python-redis.git@v1.0.0#egg=redis-opentracing
+requests-opentracing
+tornado_opentracing>=1.0.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
--e .
 django
 docker
 flake8
@@ -10,5 +9,5 @@ pytest
 pytest-django
 redis
 requests
-tornado
 six
+tornado

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-opentracing==2.0.0
-https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing
-https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing
-https://github.com/signalfx/python-dbapi/tarball/master#egg=dbapi-opentracing
-https://github.com/signalfx/python-pymongo/tarball/master#egg=pymongo-opentracing
-https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing
-https://github.com/signalfx/python-requests/tarball/master#egg=requests-opentracing
-https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client
-tornado_opentracing==1.0.1
+opentracing>=2.0,<2.1
 wrapt

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -15,13 +15,13 @@ def is_installed(library):
 jaeger_client = 'https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client'
 
 instrumentors = {
-    'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
     'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
-    'pymongo': 'https://github.com/signalfx/python-pymongo/tarball/master#egg=pymongo-opentracing',
-    'pymysql': 'https://github.com/signalfx/python-dbapi/tarball/master#egg=dbapi-opentracing',
+    'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
+    'pymongo': 'pymongo-opentracing',
+    'pymysql': 'dbapi-opentracing',
     'redis': 'https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing',
-    'requests': 'https://github.com/signalfx/python-requests/tarball/master#egg=requests-opentracing',
-    'tornado': 'tornado_opentracing==1.0.1',
+    'requests': 'requests-opentracing',
+    'tornado': 'tornado_opentracing==1.0.1'
 }
 
 
@@ -51,11 +51,14 @@ def console_script():
 def main():
     ap = ArgumentParser()
     ap.add_argument('--jaeger', action='store_true')
+    ap.add_argument('--jaeger-only', action='store_true')
     ap.add_argument('--deps-only', action='store_true')
     args = ap.parse_args()
 
-    if args.jaeger:
+    if args.jaeger or args.jaeger_only:
         install_jaeger()
+        if args.jaeger_only:
+            return
 
     install_deps()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 from setuptools import setup, find_packages
 
-
 version = '0.0.1'
 
 setup(name='signalfx-tracing',
@@ -12,7 +11,7 @@ setup(name='signalfx-tracing',
       description='Provides auto-instrumentation for OpenTracing traced libraries and frameworks',
       license='Apache Software License v2',
       classifiers=[
-          'Development Status :: 3 - Alpha',
+          'Development Status ::  4 - Beta',
           'Intended Audience :: Developers',
           'Natural Language :: English',
           'License :: OSI Approved :: Apache Software License',
@@ -25,7 +24,10 @@ setup(name='signalfx-tracing',
           'Programming Language :: Python :: 3.6',
       ],
       packages=find_packages(),
-      install_requires=['wrapt'],
+      install_requires=[
+          'opentracing==2.0.0',
+          'wrapt'
+      ],
       extras_require={
           'tests': [
               'docker',
@@ -36,6 +38,7 @@ setup(name='signalfx-tracing',
       },
       entry_points={
           'console_scripts': [
-              'sfx-py-trace = scripts.sfx_py_trace:main'
+              'sfx-py-trace = scripts.sfx_py_trace:main',
+              'sfx-py-trace-bootstrap = scripts.bootstrap:console_script'
           ]
       })

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,71 @@
 #!/usr/bin/env python
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+from setuptools.command.test import test as TestCommand
 from setuptools import setup, find_packages
+import sys
+import os
 
 version = '0.0.1'
+
+
+class PyTest(TestCommand):
+    user_options = []
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+
+    def run_tests(self):
+        import pytest
+        sys.exit(pytest.main(['tests/unit', '--ignore', 'tests/unit/libraries', '-p', 'no:django']))
+
+
+def stripped_dependencies(deps):
+    """Reduces any pip-friendly vcs/url to package name for setuptools compatibility"""
+    return [dep if 'egg=' not in dep else dep.split('egg=')[1] for dep in deps]
+
+
+def isolated_dependencies(deps):
+    """Ensures `pip install --process-dependency-links signalfx-tracing[django,jaeger,redis]` installs desired extras"""
+    # Takes advantage of limitation of pip and setuptools dependency links.
+    # Should guarantee supported instrumentor version is installed.
+    # https://github.com/pypa/pip/issues/3610#issuecomment-356687173
+    isolated = []
+    for dep in deps:
+        if 'https' in dep:
+            isolated.append('git+{}-999999999'.format(dep))
+    return isolated
+
+
+cwd = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(cwd, 'requirements.txt')) as requirements_file:
+    requirements = requirements_file.read().splitlines()
+
+with open(os.path.join(cwd, 'requirements-test.txt')) as test_requirements_file:
+    integration_test_requirements = test_requirements_file.read().splitlines()
+
+with open(os.path.join(cwd, 'requirements-inst.txt')) as inst_requirements_file:
+    instrumentors = inst_requirements_file.read().splitlines()
+    instrumentation_requirements = stripped_dependencies(instrumentors)
+    dependency_links = isolated_dependencies(instrumentors)
+
+with open(os.path.join(cwd, 'README.md')) as readme_file:
+    long_description = readme_file.read()
+
+unit_test_requirements = ['mock', 'pytest', 'six']
 
 setup(name='signalfx-tracing',
       version=version,
       author='SignalFx, Inc.',
       author_email='info@signalfx.com',
-      description='Provides auto-instrumentation for OpenTracing traced libraries and frameworks',
+      url='http://github.com/signalfx/signalfx-python-tracing',
+      download_url='http://github.com/signalfx/signalfx-python-tracing/tarball/master',
+      description='Provides auto-instrumentation for OpenTracing-traced libraries and frameworks',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
       license='Apache Software License v2',
       classifiers=[
-          'Development Status ::  4 - Beta',
+          'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',
           'Natural Language :: English',
           'License :: OSI Approved :: Apache Software License',
@@ -24,21 +78,27 @@ setup(name='signalfx-tracing',
           'Programming Language :: Python :: 3.6',
       ],
       packages=find_packages(),
-      install_requires=[
-          'opentracing==2.0.0',
-          'wrapt'
-      ],
-      extras_require={
-          'tests': [
-              'docker',
-              'mock',
-              'pytest',
-              'six',
-          ],
-      },
-      entry_points={
-          'console_scripts': [
+      install_requires=requirements,
+      tests_require=unit_test_requirements,
+      dependency_links=dependency_links,
+      extras_require=dict(
+          unit_tests=unit_test_requirements,
+          instrumentation_tests=integration_test_requirements + instrumentation_requirements,
+          # track with extras list in README
+          dbapi='dbapi-opentracing',
+          django='django-opentracing',
+          flask='flask_opentracing',
+          jaeger='jaeger-client',
+          pymongo='pymongo-opentracing',
+          pymysql='dbapi-opentracing',
+          redis='redis-opentracing',
+          requests='requests-opentracing',
+          tornado='tornado-opentracing>=1.0.1',
+      ),
+      entry_points=dict(
+          console_scripts=[
               'sfx-py-trace = scripts.sfx_py_trace:main',
               'sfx-py-trace-bootstrap = scripts.bootstrap:console_script'
           ]
-      })
+      ),
+      cmdclass=dict(test=PyTest))

--- a/tests/integration/test_jaeger_client.py
+++ b/tests/integration/test_jaeger_client.py
@@ -2,6 +2,7 @@
 import os
 
 from jaeger_client import Config, Tracer
+import opentracing.span
 import pytest
 import mock
 
@@ -36,6 +37,10 @@ class TestCreateTracer(object):
         os.environ[token_var] = 'AccessToken'
         tracer = utils.create_tracer()
         assert isinstance(tracer, Tracer)
+
+    def test_has_start_active_span(self):
+        tracer = utils.create_tracer()
+        assert isinstance(tracer.start_active_span('test_span').span, opentracing.span.Span)
 
     def test_defaults(self):
         with mock.patch('jaeger_client.Config') as cfg:

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,13 @@ envlist=
     py{27,34,35,36}-django{18,19,110,111}
     py{34,35,36}-django20
     py{35,36}-django21
-    py{27,34,35,36}-tornado{43,44,45,50,51}
     py{27,34,35,36}-flask{010,011,012,10}
-    py{27,34,35,36}-pymysql{08,09}
     py{27,34,35,36}-jaeger
     py{27,34,35,36}-pymongo{31,32,33,34,35,36,37}
+    py{27,34,35,36}-pymysql{08,09}
     py{27,34,35,36}-redis210
-    py{27,34,35,36}-requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220}
+    py{27,34,35,36}-requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220,221}
+    py{27,34,35,36}-tornado{43,44,45,50,51}
 
 [testenv]
 basepython =
@@ -20,11 +20,19 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+install_command = pip install --process-dependency-links {opts} {packages}
+extras =
+    jaeger: jaeger
+    py{27,34,35,36}: unit_tests
+    django{18,19,110,111,20,21}: django
+    flask{010,011,012,10}: flask
+    pymongo{31,32,33,34,35,36,37}: pymongo
+    pymysql{08,09}: pymysql
+    redis210: redis
+    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220,221}: requests
+    tornado{43,44,45,50,51}: tornado
 deps =
     flake8: flake8
-    py{27,34,35,36}: pytest
-    py{27,34,35,36}: mock
-    py{27,34,35,36}: -rrequirements.txt
     django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
     django18: django>=1.8,<1.9
@@ -63,6 +71,7 @@ deps =
     requests218: requests>=2.18,<2.19
     requests219: requests>=2.19,<2.20
     requests220: requests>=2.20,<2.21
+    requests221: requests>=2.21,<2.22
     requests21: requests>=2.1,<2.2
     requests22: requests>=2.2,<2.3
     requests23: requests>=2.3,<2.4
@@ -72,19 +81,18 @@ deps =
     requests27: requests>=2.7,<2.8
     requests28: requests>=2.8,<2.9
     requests29: requests>=2.9,<2.10
-    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220}: docker
+    requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220,221}: docker
     tornado43: tornado>=4.3,<4.4
     tornado44: tornado>=4.4,<4.5
     tornado45: tornado>=4.5,<5.0
     tornado50: tornado>=5.0,<5.1
     tornado51: tornado>=5.1,<5.2
     tornado{43,44,45,50,51}: requests
-
-commands = 
+commands =
     flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
     py{27,34,35,36}-unit: pytest tests/unit --ignore tests/unit/libraries -p no:django
-    django{18,19,110,111,20,21}: pytest tests/integration/django_
     django{18,19,110,111,20,21}: pytest tests/unit/libraries/django_
+    django{18,19,110,111,20,21}: pytest tests/integration/django_
     flask{010,011,012,10}: pytest tests/integration/flask_
     flask{010,011,012,10}: pytest tests/unit/libraries/flask_
     jaeger: sfx-py-trace-bootstrap
@@ -100,6 +108,19 @@ commands =
     requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220}: pytest tests/unit/libraries/requests_
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
     tornado{43,44,45,50,51}: pytest tests/unit/libraries/tornado_
+
+
+[testenv:py27-jaeger]
+alwayscopy = true
+
+[testenv:py34-jaeger]
+alwayscopy = true
+
+[testenv:py35-jaeger]
+alwayscopy = true
+
+[testenv:py36-jaeger]
+alwayscopy = true
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands =
     django{18,19,110,111,20,21}: pytest tests/unit/libraries/django_
     flask{010,011,012,10}: pytest tests/integration/flask_
     flask{010,011,012,10}: pytest tests/unit/libraries/flask_
-    jaeger: ./bootstrap.py --jaeger
+    jaeger: sfx-py-trace-bootstrap
     jaeger: pytest tests/integration/test_jaeger_client.py
     jaeger: pytest tests/integration/test_runner.py
     pymongo{31,32,33,34,35,36,37}: pytest tests/integration/pymongo_


### PR DESCRIPTION
Currently the requirements file and bootstrap process present users with an all or nothing dependency installation choice and the expectation that they've cloned the project repo.  These changes add an `sfx-py-trace-bootstrap` entry point for automatic instrumentor and tracer installation.  Also included are the option of instrumentor installations as package extras w/ a split instrumentor requirements file as the source of truth.