### PR TITLE
Ensure sfx-py-trace-bootstrap installs desired libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The SignalFx-Tracing Library for Python works by detecting your libraries and fr
 instrumentors for distributed tracing via the Python [OpenTracing API 2.0](https://pypi.org/project/opentracing/2.0.0/). 
 By default, its footprint is small and doesn't declare any instrumentors as dependencies. That is, it operates on the
 assumption that you have 2.0-compatible instrumentors installed as needed. As adoption of this API is done on a
-per-instrumentor basis, it's highly recommended you use the helpful bootstrap utility for obtaining and installing any
-applicable, feature-ready instrumentors along with a compatible tracer:
+per-instrumentor basis, it's highly recommended you use the helpful [bootstrap utility](./scripts/README.md) for
+obtaining and installing any applicable, feature-ready instrumentors along with a compatible tracer:
 
 ```sh
  $ pip install signalfx-tracing

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+# SignalFx-Tracing Library for Python Utilities
+
+## sfx-py-trace-bootstrap
+
+As the overall aim of SignalFx-Tracing is the auto-instrumentation of your application, automatically providing each
+library instrumentation as it is needed is preferrable to manually managing packages for each deployment
+environment or introducing a number of superfluous dependencies.  To assist in this aim, `sfx-py-trace-bootstrap` is
+available to all SignalFx-Tracing installations.  It will check your current environment for traceable libraries,
+uninstall any existing instrumentations for them, and install a supported instrumentation version for use with
+`signalfx_tracing.instrument()`.  It will also install an updated version of the Jaeger tracer, uninstalling any
+existing version beforehand.  An error is raised if any dependency conflicts are detected involving our installed
+instrumentations.
+
+Currently this utility only supports the [Pip](https://pip.pypa.io/en/stable/) package installer, and its behavior is
+roughly analogous to the following process for each supported library:
+
+```python
+import subprocess
+
+try:
+    import my_supported_library
+    subprocess.Popen(['pip', 'uninstall', '-y', my_supported_library_instrumentation])
+    subprocess.Popen(['pip', 'install', '-U', my_supported_library_instrumentation])
+except ImportError:
+    pass
+```
+
+Other package installers are expected to be supported in the future, and if you have one you'd like us to support,
+please feel free to open a GitHub issue.  `sfx-py-trace-bootstrap` is our preferred installation utility, but if you'd
+rather manage your instrumentations manually, we also suggest using the provided
+[package extras](../README.md#library-and-instrumentors).
+
+
+## sfx-py-trace
+
+This utility is available to all SignalFx-Tracing installations and provides users with the automatic configuration of
+available instrumentations and Jaeger tracer for their Python applications via a console script, assuming they have
+run `sfx-py-trace-bootstrap` or installed the required dependencies as package extras:
+
+```sh
+ $ # SIGNALFX_INGEST_URL should be a deployed Smart Gateway trace endpoint
+ $ SIGNALFX_INGEST_URL='http://localhost:9080/v1/trace' sfx-py-trace my_application.py --app_arg_one --app_arg_two
+```
+
+Because of our modified Jaeger tracer's Tornado dependency and its known limitations, the `sfx-py-trace` utility is not
+currently a substitute for a system Python executable and must be provided a target Python script or path with a
+`__main__` module. There are plans to remove the Tornado dependency that will allow us to enhance the script runner's
+functionality in other environments and use cases.

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -23,20 +23,72 @@ instrumentors = {
     'pymysql': 'dbapi-opentracing',
     'redis': 'https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing',
     'requests': 'requests-opentracing',
-    'tornado': 'tornado_opentracing==1.0.1'
+    'tornado': 'tornado-opentracing==1.0.1'
 }
+
+packages = {
+    'django': 'django-opentracing',
+    'flask': 'Flask-OpenTracing',
+    'jaeger': 'jaeger-client',
+    'psycopg2': 'dbapi-opentracing',
+    'pymongo': 'pymongo-opentracing',
+    'pymysql': 'dbapi-opentracing',
+    'redis': 'redis-opentracing',
+    'requests': 'requests-opentracing',
+    'signalfx-tracing': 'signalfx-tracing',
+    'tornado': 'tornado-opentracing'
+}
+
+
+def _install_updated_dependency(library, package_path):
+    """
+    Ensures that desired version is installed w/o upgrading its dependencies by uninstalling where necessary.
+
+    OpenTracing-Contrib often has traced library as instrumentation dependency (e.g. Django for django-opentracing),
+    so using -I on library will cause likely undesired Django upgrade.  Using --no-dependencies alone would
+    leave potential for nonfunctional installations.
+    """
+    pip_list = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze']).decode().lower()
+    path = packages[library]
+    if '{}=='.format(path).lower() in pip_list:
+        print('Existing {} installation detected.  Uninstalling.'.format(path))
+        subprocess.check_call([sys.executable, '-m', 'pip', 'uninstall', '-y', path])
+
+    # explicit upgrade strategy to override potential pip config
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-U',
+                           '--upgrade-strategy', 'only-if-needed', package_path])
+    _pip_check()
+
+
+def _pip_check():
+    """Ensures none of the signalfx-tracing instrumentations have dependency conflicts.
+
+    Clean check reported as:
+    'No broken requirements found.'
+
+    Dependency conflicts are reported as:
+    'django-opentracing 1.0.1 has requirement opentracing<2.1,>=2.0, but you have opentracing 1.3.0.'
+
+    To not be too restrictive, we'll only check for relevant packages.
+    """
+    check_pipe = subprocess.Popen([sys.executable, '-m', 'pip', 'check'], stdout=subprocess.PIPE)
+    pip_check = check_pipe.communicate()[0].decode()
+    pip_check_lower = pip_check.lower()
+    for package in packages.values():
+        if package.lower() in pip_check_lower:
+            raise RuntimeError('Dependency conflict found: {}'.format(pip_check))
 
 
 def install_jaeger():
     print('Installing Jaeger Client.')
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', jaeger_client])
+    _install_updated_dependency('jaeger', jaeger_client)
 
 
 def install_deps():
     for library, instrumentor in instrumentors.items():
         if is_installed(library):
             print('Installing {} instrumentor.'.format(library))
-            subprocess.check_call([sys.executable, '-m', 'pip', 'install', instrumentor])
+            _install_updated_dependency(library, instrumentor)
 
 
 def install_sfx_py_trace():

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,12 @@
 envlist=
     flake8
     py{27,34,35,36}-unit
-    py{27,34,35,36}-django{18,19,110,111}
-    py{34,35,36}-django20
-    py{35,36}-django21
-    py{27,34,35,36}-flask{010,011,012,10}
+    py{27,34,35,36}-django18-via-bootstrap
+    py{27,34,35,36}-django{18,19,110,111}-via-extras
+    py{34,35,36}-django20-via-extras
+    py{35,36}-django21-via-extras
+    py{27,34,35,36}-flask010-via-bootstrap
+    py{27,34,35,36}-flask{010,011,012,10}-via-extras
     py{27,34,35,36}-jaeger
     py{27,34,35,36}-psycopg2-27
     py{27,34,35,36}-pymongo{31,32,33,34,35,36,37}
@@ -25,8 +27,8 @@ install_command = pip install --process-dependency-links {opts} {packages}
 extras =
     jaeger: jaeger
     py{27,34,35,36}: unit_tests
-    django{18,19,110,111,20,21}: django
-    flask{010,011,012,10}: flask
+    django{18,19,110,111,20,21}-via-extras: django
+    flask{010,011,012,10}-via-extras: flask
     psycopg2-27: psycopg2
     pymongo{31,32,33,34,35,36,37}: pymongo
     pymysql{08,09}: pymysql
@@ -95,11 +97,19 @@ deps =
 commands =
     flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
     py{27,34,35,36}-unit: pytest tests/unit --ignore tests/unit/libraries -p no:django
+    django18-via-bootstrap: pip install -U django-opentracing # provides coverage for desired version installation via bootstrap
+    django18-via-bootstrap: sfx-py-trace-bootstrap
+    django18-via-bootstrap: pip check
     django{18,19,110,111,20,21}: pytest tests/unit/libraries/django_
     django{18,19,110,111,20,21}: pytest tests/integration/django_
+    flask010-via-bootstrap: pip install -U flask-opentracing # provides coverage for desired version installation via bootstrap
+    flask010-via-bootstrap: sfx-py-trace-bootstrap
+    flask010-via-bootstrap: pip check
     flask{010,011,012,10}: pytest tests/integration/flask_
     flask{010,011,012,10}: pytest tests/unit/libraries/flask_
+    jaeger: pip install -U jaeger-client # provides coverage for desired version installation via bootstrap
     jaeger: sfx-py-trace-bootstrap
+    jaeger: pip check
     jaeger: pytest tests/integration/test_jaeger_client.py
     jaeger: pytest tests/integration/test_runner.py
     psycopg2-27: pytest tests/unit/libraries/psycopg2_


### PR DESCRIPTION
Adds an additional uninstallation step to the bootstrap utility to ensure that the desired version of instrumentations and Jaeger are installed.  Also includes updated docs and some test coverage via installing undesired tracer and instrumentation versions before running bootstrap and integration tests for Django, Flask, and Jaeger.