### PR TITLE
Add Elasticsearch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ def untraced_route():
 ## Supported Frameworks and Libraries
 
 * [Django 1.8+](./signalfx_tracing/libraries/django_/README.md) - `instrument(django=True)`
+* [Elasticsearch 2.0+](./signalfx_tracing/libraries/elasticsearch_/README.md) - `instrument(elasticsearch=True)`
 * [Flask 0.10+](./signalfx_tracing/libraries/flask_/README.md) - `instrument(flask=True)`
 * [Psycopg 2.7+](./signalfx_tracing/libraries/psycopg2_/README.md) - `instrument(psycopg2=True)`
 * [PyMongo 3.1+](./signalfx_tracing/libraries/pymongo_/README.md) - `instrument(pymongo=True)`

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,5 +1,6 @@
 dbapi-opentracing
 https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
 https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
 https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender#egg=jaeger-client
 pymongo-opentracing

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 django
 docker
+elasticsearch
 flake8
 mock
 mockupdb

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -17,6 +17,8 @@ jaeger_client = 'https://github.com/signalfx/jaeger-client-python/tarball/ot_20_
 
 instrumentors = {
     'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
+    'elasticsearch': ('https://github.com/signalfx/python-elasticsearch/tarball/2.0_support_multiple_versions'
+                      '#egg=elasticsearch-opentracing'),
     'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
     'psycopg2': 'dbapi-opentracing',
     'pymongo': 'pymongo-opentracing',
@@ -28,6 +30,7 @@ instrumentors = {
 
 packages = {
     'django': 'django-opentracing',
+    'elasticsearch': 'elasticsearch-opentracing',
     'flask': 'Flask-OpenTracing',
     'jaeger': 'jaeger-client',
     'psycopg2': 'dbapi-opentracing',

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(name='signalfx-tracing',
           # track with extras list in README
           dbapi='dbapi-opentracing',
           django='django-opentracing',
+          elasticsearch='elasticsearch-opentracing',
           flask='flask_opentracing',
           jaeger='jaeger-client',
           psycopg2='dbapi-opentracing',

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2018-2019 SignalFx, Inc. All rights reserved.
 
 instrumented_attr = '__sfx_instrumented'
-traceable_libraries = ('django', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
-auto_instrumentable_libraries = ('flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
+traceable_libraries = ('django', 'elasticsearch', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests',
+                       'tornado')
+auto_instrumentable_libraries = ('elasticsearch', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests',
+                                 'tornado')

--- a/signalfx_tracing/libraries/__init__.py
+++ b/signalfx_tracing/libraries/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2018-2019 SignalFx, Inc. All rights reserved.
 from .django_ import config as django_config  # noqa
+from .elasticsearch_ import config as elasticsearch_config  # noqa
 from .flask_ import config as flask_config  # noqa
 from .psycopg2_ import config as psycopg2_config  # noqa
 from .pymongo_ import config as pymongo_config  # noqa

--- a/signalfx_tracing/libraries/elasticsearch_/README.md
+++ b/signalfx_tracing/libraries/elasticsearch_/README.md
@@ -1,0 +1,54 @@
+# Elasticsearch
+
+- [opentracing-contrib/python-elasticsearch](https://github.com/opentracing-contrib/python-elasticsearch)
+- [Official Site](https://www.elastic.co/products/elasticsearch)
+
+The SignalFx Auto-instrumentor configures the OpenTracing Project's Elasticsearch instrumentation for your Elasticsearch
+2.0+ clients.  You can enable instrumentation of your client functionality with a call to the
+`signalfx_tracing.auto_instrument()` function before initializing your `Elasticsearch` or
+`elasticsearch.transport.Transport` object. To configure tracing, some tunables are provided via `elasticsearch_config`
+to establish the desired tracer and operation name prefix.
+
+| Setting name | Definition | Default value |
+| -------------|------------|---------------|
+| prefix | The prefix to use in all span operation names  | `'Elasticsearch'` |
+| tracer | An instance of an OpenTracing-compatible tracer for all Elasticsearch traces. | `opentracing.tracer` |
+
+```python
+# my_app.py
+import datetime
+
+from signalfx_tracing.libraries import elasticsearch_config
+from signalfx_tracing import auto_instrument, instrument
+import elasticsearch
+
+# ***
+# The SignalFx Elasticsearch auto-instrumentor works by monkey patching elasticsearch.transport.Transport creation.
+# You must invoke auto_instrument() or instrument() before instantiating your Elasticsearch client.
+#
+# from sfx_tracing import instrument
+# instrument(elasticsearch=True)  # or sfx_tracing.auto_instrument()
+# instrumented_client = elasticsearch.Elasticsearch(...)
+#
+# Importing Elasticsearch from its parent elasticsearch module object requires no advanced instrumentation
+# beyond that of pre-initialization:
+#
+# from sfx_tracing import instrument
+# from elasticsearch import Elasticsearch
+#
+# instrument(elasticsearch=True)  # or sfx_tracing.auto_instrument()
+# instrumented_client = Elasticsearch(...)
+#
+# ***
+
+elasticsearch_config.prefix = 'MyInformativePrefix'
+
+# Ignored if tracer argument provided to instrument() or auto_instrument()
+elasticsearch_config.tracer = MyTracer()
+
+auto_instrument()  # or instrument(elasticsearch=True)
+
+es = elasticsearch.Elasticsearch()  # Traced client
+es.index(index='my-index', doc_type='my-type', id=1, body={'my': 'data', 'timestamp': datetime.now()})  # Traced methods
+es.get(index='my-index', doc_type='my-type', id=1)
+```

--- a/signalfx_tracing/libraries/elasticsearch_/__init__.py
+++ b/signalfx_tracing/libraries/elasticsearch_/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+from .instrument import config, instrument, uninstrument  # noqa

--- a/signalfx_tracing/libraries/elasticsearch_/instrument.py
+++ b/signalfx_tracing/libraries/elasticsearch_/instrument.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+import opentracing
+
+from signalfx_tracing import utils
+
+# Configures Elasticsearch tracing as described by
+# https://github.com/opentracing-contrib/python-elasticsearch/blob/master/README.rst
+config = utils.Config(
+    prefix='Elasticsearch',
+    tracer=None,
+)
+
+_transport_new = [None]
+_tracing_transport_new = [None]
+
+
+def transport_new(_, __, *args, **kwargs):
+    """Monkey patch Transport.__new__() to create a TracingTransport object"""
+    from elasticsearch_opentracing import TracingTransport
+    return TracingTransport.__new__(TracingTransport, *args, **kwargs)
+
+
+def tracing_transport_new(_, __, *args, **kwargs):
+    """Monkey patch a valid TracingTransport.__new__() to avoid recursion on patched base class"""
+    from elasticsearch_opentracing import TracingTransport
+    return object.__new__(TracingTransport)
+
+
+def instrument(tracer=None):
+    """
+    Elasticsearch auto-instrumentation works by hooking a __new__ proxy for a TracingTransport
+    instance upon elasticsearch.transports.Transport initialization to trigger proper inheritance.
+    """
+    elasticsearch = utils.get_module('elasticsearch')
+    if utils.is_instrumented(elasticsearch):
+        return
+
+    from elasticsearch_opentracing import init_tracing, TracingTransport
+
+    _tracer = tracer or config.tracer or opentracing.tracer
+    init_tracing(_tracer, trace_all_requests=True, prefix=config.prefix)
+
+    _transport_new[0] = elasticsearch.transport.Transport.__new__
+    _tracing_transport_new[0] = TracingTransport.__new__
+
+    TracingTransport.__new__ = tracing_transport_new.__get__(TracingTransport)
+    elasticsearch.transport.Transport.__new__ = transport_new.__get__(elasticsearch.transport.Transport)
+
+    utils.mark_instrumented(elasticsearch)
+
+
+def uninstrument():
+    elasticsearch = utils.get_module('elasticsearch')
+    if not utils.is_instrumented(elasticsearch):
+        return
+
+    from elasticsearch_opentracing import disable_tracing, TracingTransport
+    disable_tracing()
+
+    # because of https://bugs.python.org/issue25731 we cannot simply restore
+    # built-in __new__.  Use a generic implementation as a workaround
+    def __new__(cls, *_, **__):
+        return object.__new__(cls)
+
+    if _tracing_transport_new[0] is not None:
+        if hasattr(_tracing_transport_new[0], '__get__'):
+            TracingTransport.__new__ = _tracing_transport_new[0].__get__(TracingTransport)
+        else:  # builtin doesn't follow descriptor protocol
+            TracingTransport.__new__ = __new__.__get__(TracingTransport)
+        _tracing_transport_new[0] = None
+
+    if _transport_new[0] is not None:
+        if hasattr(_transport_new[0], '__get__'):
+            elasticsearch.transport.Transport.__new__ = _transport_new[0].__get__(elasticsearch.transport.Transport)
+        else:
+            elasticsearch.transport.Transport.__new__ = __new__.__get__(elasticsearch.transport.Transport)
+        _transport_new[0] = None
+    utils.mark_uninstrumented(elasticsearch)

--- a/tests/integration/elasticsearch_/__init__.py
+++ b/tests/integration/elasticsearch_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.

--- a/tests/integration/elasticsearch_/conftest.py
+++ b/tests/integration/elasticsearch_/conftest.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+
+
+def pytest_addoption(parser):
+    parser.addoption('--elasticsearch-image-version', action='store', default='6.5.4')

--- a/tests/integration/elasticsearch_/test_instrumented_transport.py
+++ b/tests/integration/elasticsearch_/test_instrumented_transport.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+from time import sleep
+
+from opentracing.mocktracer import MockTracer
+import elasticsearch
+import docker
+import pytest
+
+from signalfx_tracing.libraries import elasticsearch_config
+from signalfx_tracing import instrument, uninstrument
+from tests.utils import random_int
+
+
+@pytest.fixture(scope='session')
+def elasticsearch_container(request):
+    es_version = request.config.getoption('--elasticsearch-image-version', '6.5.4')
+    docker_client = docker.from_env()
+    es_container = docker_client.containers.run('elasticsearch:{}'.format(es_version),
+                                                ports={'9200/tcp': 9200}, detach=True)
+    try:
+        es_client = elasticsearch.Elasticsearch()
+        for i in range(60):
+            try:
+                if es_client.ping():
+                    break
+            except elasticsearch.ConnectionError:
+                pass
+
+            if i == 59:
+                raise RuntimeError('Failed to connect to Elasticsearch.')
+            sleep(.5)
+
+        yield es_container
+    finally:
+        es_container.remove(v=True, force=True)
+
+
+class TestElasticsearch(object):
+
+    @pytest.fixture
+    def tracer(self, elasticsearch_container):
+        yield MockTracer()
+
+    @pytest.fixture
+    def instrumented_elasticsearch(self, tracer):
+        elasticsearch_config.prefix = 'MyPrefix'
+        yield instrument(tracer, elasticsearch=True)
+        uninstrument('elasticsearch')
+
+    @pytest.fixture
+    def tracer_and_elasticsearch(self, tracer):
+        return tracer, elasticsearch.Elasticsearch()
+
+    @pytest.fixture
+    def tracer_and_elasticsearch_transport(self, tracer):
+        return tracer, elasticsearch.Elasticsearch(transport=elasticsearch.Transport)
+
+    @pytest.fixture
+    def tracer_and_elasticsearch_transport_transport(self, tracer):
+        import elasticsearch.transport  # must be imported after auto-instrumentation
+        return tracer, elasticsearch.Elasticsearch(transport=elasticsearch.transport.Transport)
+
+    @pytest.fixture(params=('tracer_and_elasticsearch', 'tracer_and_elasticsearch_transport',
+                            'tracer_and_elasticsearch_transport_transport'))
+    def tracer_and_client(self, request, instrumented_elasticsearch):
+        yield request.getfixturevalue(request.param)
+
+    @pytest.fixture(params=('tracer_and_elasticsearch', 'tracer_and_elasticsearch_transport',
+                            'tracer_and_elasticsearch_transport_transport'))
+    def tracer_and_uninstrumented_client(self, request):
+        uninstrument('elasticsearch')
+        yield request.getfixturevalue(request.param)
+
+    def test_uninstrumented_not_traced(self, instrumented_elasticsearch, tracer_and_uninstrumented_client):
+        tracer, es = tracer_and_uninstrumented_client
+
+        doc_id = random_int(0)
+        body = dict(lorem='ipsum' * 1024)
+        index = es.index(index='some-index', doc_type='some-doc-type', id=doc_id, body=body, params={'refresh': 'true'})
+        doc_id = str(doc_id)
+        assert index['_id'] == doc_id
+        assert index.get('result') == 'created' or index.get('created')
+        lorem = es.get(index='some-index', doc_type='some-doc-type', id=doc_id)
+        assert lorem['_id'] == doc_id
+        assert lorem['_source'] == body
+
+        assert not tracer.finished_spans()
+
+    def test_add_and_get_document(self, tracer_and_client):
+        tracer, es = tracer_and_client
+
+        doc_id = random_int(0)
+        body = dict(lorem='ipsum' * 1024)
+        index = es.index(index='some-index', doc_type='some-doc-type', id=doc_id, body=body, params={'refresh': 'true'})
+        doc_id = str(doc_id)
+        assert index['_id'] == doc_id
+        assert index.get('result') == 'created' or index.get('created')
+        lorem = es.get(index='some-index', doc_type='some-doc-type', id=doc_id)
+        assert lorem['_id'] == doc_id
+        assert lorem['_source'] == body
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 2
+        expected_url = '/some-index/some-doc-type/{}'.format(doc_id)
+        for span in spans:
+            assert span.operation_name == 'MyPrefix{}'.format(expected_url)
+            assert span.tags['elasticsearch.url'] == expected_url
+            assert span.tags['component'] == 'elasticsearch-py'

--- a/tests/unit/libraries/elasticsearch_/__init__.py
+++ b/tests/unit/libraries/elasticsearch_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.

--- a/tests/unit/libraries/elasticsearch_/conftest.py
+++ b/tests/unit/libraries/elasticsearch_/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+import unittest
+
+import pytest
+
+from signalfx_tracing.libraries.elasticsearch_.instrument import config, uninstrument
+
+
+class ElasticsearchTestSuite(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def restored_elasticsearch_config(self):
+        orig = dict(config.__dict__)
+        yield
+        config.__dict__ = orig
+
+    @pytest.fixture(autouse=True)
+    def uninstrument_elasticsearch(self):
+        yield
+        uninstrument()

--- a/tests/unit/libraries/elasticsearch_/test_elasticsearch.py
+++ b/tests/unit/libraries/elasticsearch_/test_elasticsearch.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+from contextlib import contextmanager
+
+from opentracing.mocktracer import MockTracer
+from elasticsearch import Elasticsearch, VERSION
+from opentracing.ext import tags
+from mock import patch
+import opentracing
+
+from signalfx_tracing.libraries.elasticsearch_ import config, instrument, uninstrument
+from .conftest import ElasticsearchTestSuite
+
+
+class TestElasticsearch(ElasticsearchTestSuite):
+
+    body = dict(body='body')
+
+    @contextmanager
+    def mocked_transport(self):
+        with patch('elasticsearch.transport.Transport.perform_request') as perform_request:
+            if VERSION < (5, 0, 0):
+                perform_request.return_value = False, dict(some='thing')
+            yield perform_request
+
+    def test_trace_with_default_config(self):
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        instrument()
+
+        with self.mocked_transport() as perform_request:
+            es = Elasticsearch()
+            es.index(index='some-index', doc_type='some-doc-type',
+                     id=1, body=self.body)
+            assert perform_request.called
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.operation_name == 'Elasticsearch/some-index/some-doc-type/1'
+        assert span.tags == {'component': 'elasticsearch-py',
+                             tags.DATABASE_STATEMENT: str(self.body),
+                             tags.DATABASE_TYPE: 'elasticsearch',
+                             'elasticsearch.method': 'PUT',
+                             'elasticsearch.url': '/some-index/some-doc-type/1',
+                             'span.kind': 'client'}
+
+    def test_trace_with_updated_config(self):
+        tracer = MockTracer()
+        config.tracer = tracer
+        config.prefix = 'SomePrefix'
+        instrument()
+
+        with self.mocked_transport() as perform_request:
+            es = Elasticsearch()
+            es.index(index='some-index', doc_type='some-doc-type',
+                     id=1, body=self.body)
+            assert perform_request.called
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.operation_name == 'SomePrefix/some-index/some-doc-type/1'
+        assert span.tags == {'component': 'elasticsearch-py',
+                             tags.DATABASE_STATEMENT: str(self.body),
+                             tags.DATABASE_TYPE: 'elasticsearch',
+                             'elasticsearch.method': 'PUT',
+                             'elasticsearch.url': '/some-index/some-doc-type/1',
+                             'span.kind': 'client'}
+
+    def test_uninstrument_reverts_wrapper(self):
+        tracer = MockTracer()
+        instrument(tracer)
+
+        with self.mocked_transport() as perform_request:
+            es = Elasticsearch()
+            es.index(index='some-index', doc_type='some-doc-type',
+                     id=1, body=self.body)
+            assert perform_request.called
+
+        assert len(tracer.finished_spans()) == 1
+
+        tracer.reset()
+        uninstrument()
+
+        with self.mocked_transport() as perform_request:
+            es = Elasticsearch()
+            es.index(index='some-index', doc_type='some-doc-type',
+                     id=1, body=self.body)
+            assert perform_request.called
+
+        assert not tracer.finished_spans()

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -21,9 +21,10 @@ else:
                 stack.enter_context(context)
             yield
 
-
-expected_traceable_libraries = ('django', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
-expected_auto_instrumentable_libraries = ('flask', 'psycopg2', 'pymongo', 'pymysql', 'redis', 'requests', 'tornado')
+expected_traceable_libraries = ('django', 'elasticsearch', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis',
+                                'requests', 'tornado')
+expected_auto_instrumentable_libraries = ('elasticsearch', 'flask', 'psycopg2', 'pymongo', 'pymysql', 'redis',
+                                          'requests', 'tornado')
 
 
 class TestInstrument(object):
@@ -39,6 +40,7 @@ class TestInstrument(object):
         Without doing so, all instrumented libraries would need to be available
         in pytest context and this would effectively be a large e2e.
         """
+
         class Stub(object):  # Use a generic object for attribute loading
             pass
 
@@ -62,7 +64,6 @@ class TestInstrument(object):
 
             # Ensure stubbed module references are immutable in closure patches
             def wrap_env(module_stub):
-
                 def _instrument(tracer=None):
                     utils.mark_instrumented(module_stub)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+import random
+import sys
+
+min_int = -sys.maxsize - 1
+max_int = sys.maxsize
+
+_random_int_store = set()
+
+try:  # python 2
+    range = xrange
+except NameError:
+    pass
+
+
+def random_int(min=min_int, max=max_int):
+    """
+    Returns a unique int [min, max], raising Exception if not available.
+    Default min is -sys.maxsize - 1 and default max is sys.maxsize.
+    """
+    for _ in range(min, max):
+        num = random.randint(min, max)
+        if num not in _random_int_store:
+            _random_int_store.add(num)
+            return num
+    raise Exception('Unable to create unique random int in range [{}, {}]'.format(min, max))

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist=
     py{27,34,35,36}-django{18,19,110,111}-via-extras
     py{34,35,36}-django20-via-extras
     py{35,36}-django21-via-extras
+    py{27,34,35,36}-elasticsearch{20,21,22,23,24,50,51,52,53,54,55,60,61,62,63}
     py{27,34,35,36}-flask010-via-bootstrap
     py{27,34,35,36}-flask{010,011,012,10}-via-extras
     py{27,34,35,36}-jaeger
@@ -28,6 +29,7 @@ extras =
     jaeger: jaeger
     py{27,34,35,36}: unit_tests
     django{18,19,110,111,20,21}-via-extras: django
+    elasticsearch{20,21,22,23,24,50,51,52,53,54,55,60,61,62,63}: elasticsearch
     flask{010,011,012,10}-via-extras: flask
     psycopg2-27: psycopg2
     pymongo{31,32,33,34,35,36,37}: pymongo
@@ -44,6 +46,22 @@ deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django{18,19,110,111,20,21}: pytest-django
+    elasticsearch20: elasticsearch>=2.0,<2.1
+    elasticsearch21: elasticsearch>=2.1,<2.2
+    elasticsearch22: elasticsearch>=2.2,<2.3
+    elasticsearch23: elasticsearch>=2.3,<2.4
+    elasticsearch24: elasticsearch>=2.4,<2.5
+    elasticsearch50: elasticsearch>=5.0,<5.1
+    elasticsearch51: elasticsearch>=5.1,<5.2
+    elasticsearch52: elasticsearch>=5.2,<5.3
+    elasticsearch53: elasticsearch>=5.3,<5.4
+    elasticsearch54: elasticsearch>=5.4,<5.5
+    elasticsearch55: elasticsearch>=5.5,<5.6
+    elasticsearch60: elasticsearch>=6.0,<6.1
+    elasticsearch61: elasticsearch>=6.1,<6.2
+    elasticsearch62: elasticsearch>=6.2,<6.3
+    elasticsearch63: elasticsearch>=6.3,<6.4
+    elasticsearch{20,21,22,23,24,50,51,52,53,54,55,60,61,62,63}: docker
     flask010: flask>=0.10,<0.11
     flask011: flask>=0.11,<0.12
     flask012: flask>=0.12,<0.13
@@ -102,6 +120,10 @@ commands =
     django18-via-bootstrap: pip check
     django{18,19,110,111,20,21}: pytest tests/unit/libraries/django_
     django{18,19,110,111,20,21}: pytest tests/integration/django_
+    elasticsearch{20,21,22,23,24}: pytest --elasticsearch-image-version 2.4.6 tests/integration/elasticsearch_
+    elasticsearch{50,51,52,53,54,55}: pytest --elasticsearch-image-version 5.6.14 tests/integration/elasticsearch_
+    elasticsearch{60,61,62,63}: pytest --elasticsearch-image-version 6.5.4 tests/integration/elasticsearch_
+    elasticsearch{20,21,22,23,24,50,51,52,53,54,55,60,61,62,63}: pytest tests/unit/libraries/elasticsearch_
     flask010-via-bootstrap: pip install -U flask-opentracing # provides coverage for desired version installation via bootstrap
     flask010-via-bootstrap: sfx-py-trace-bootstrap
     flask010-via-bootstrap: pip check
@@ -124,7 +146,6 @@ commands =
     requests{20,21,22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,218,219,220}: pytest tests/unit/libraries/requests_
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
     tornado{43,44,45,50,51}: pytest tests/unit/libraries/tornado_
-
 
 [testenv:py27-jaeger]
 alwayscopy = true


### PR DESCRIPTION
Adds auto-instrumentor support for our current fork of elasticsearch-opentracing (https://github.com/signalfx/python-elasticsearch/tree/2.0_support_multiple_versions) that provides api 2.0 functionality, elasticsearch-py 6+ compatibility fix, and db statement truncation.