### PR TITLE
Remove dependency link usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,8 @@ It's also possible to install the supported instrumentors as package extras:
 
 ```bash
   # Supported extras are dbapi, django, flask, pymongo, pymysql, redis, requests, tornado
-  $ pip install --process-dependency-links 'signalfx-tracing[django,redis,requests]'
+  $ pip install 'signalfx-tracing[django,redis,requests]'
 ```
-
-**Note: It's necessary to include `--process-dependency-links` to obtain the desired instrumentor versions.**
 
 ### Tracer
 Not all stable versions of OpenTracing-compatible tracers support the 2.0 API, so we provide
@@ -103,8 +101,8 @@ ready for reporting to SignalFx. You can obtain an instance of the suggested Jae
 ```sh
   $ sfx-py-trace-bootstrap
 
-  # or as package extra (please note required --process-dependency-links)
-  $ pip install --process-dependency-links 'signalfx-tracing[jaeger]'
+  # or as package extra
+  $ pip install 'signalfx-tracing[jaeger]'
 
   # or from project source tree, along with applicable instrumentors
   $ scripts/bootstrap.py --jaeger

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,9 +1,9 @@
 dbapi-opentracing
-git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
-git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
-git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
-git+https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender#egg=jaeger-client
+django-opentracing @ git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
+elasticsearch-opentracing @ git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
+flask_opentracing @ git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
+jaeger-client @ git+https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender#egg=jaeger-client
 pymongo-opentracing
-git+https://github.com/opentracing-contrib/python-redis.git@v1.0.0#egg=redis-opentracing
+redis-opentracing @ git+https://github.com/opentracing-contrib/python-redis.git@v1.0.0#egg=redis-opentracing
 requests-opentracing
 tornado_opentracing>=1.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist=
     py{27,34,35,36}-elasticsearch{20,21,22,23,24,50,51,52,53,54,55,60,61,62,63}
     py{27,34,35,36}-flask010-via-bootstrap
     py{27,34,35,36}-flask{010,011,012,10}-via-extras
-    py{27,34,35,36}-jaeger
+    py{27,34,35,36}-jaeger-pip{18,19}
     py{27,34,35,36}-psycopg2-27
     py{27,34,35,36}-pymongo{31,32,33,34,35,36,37}
     py{27,34,35,36}-pymysql{08,09}
@@ -24,7 +24,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
-install_command = pip install --process-dependency-links {opts} {packages}
+install_command = pip install {opts} {packages}
 extras =
     jaeger: jaeger
     py{27,34,35,36}: unit_tests
@@ -114,6 +114,8 @@ deps =
     tornado{43,44,45,50,51}: requests
 commands =
     flake8: flake8 setup.py bootstrap.py signalfx_tracing tests
+    pip18: pip install pip>=18,<19
+    pip19: pip install pip>=19,<20
     py{27,34,35,36}-unit: pytest tests/unit --ignore tests/unit/libraries -p no:django
     django18-via-bootstrap: pip install -U django-opentracing # provides coverage for desired version installation via bootstrap
     django18-via-bootstrap: sfx-py-trace-bootstrap
@@ -147,16 +149,28 @@ commands =
     tornado{43,44,45,50,51}: pytest tests/integration/tornado_
     tornado{43,44,45,50,51}: pytest tests/unit/libraries/tornado_
 
-[testenv:py27-jaeger]
+[testenv:py27-jaeger-pip18]
 alwayscopy = true
 
-[testenv:py34-jaeger]
+[testenv:py27-jaeger-pip19]
 alwayscopy = true
 
-[testenv:py35-jaeger]
+[testenv:py34-jaeger-pip18]
 alwayscopy = true
 
-[testenv:py36-jaeger]
+[testenv:py34-jaeger-pip19]
+alwayscopy = true
+
+[testenv:py35-jaeger-pip18]
+alwayscopy = true
+
+[testenv:py35-jaeger-pip19]
+alwayscopy = true
+
+[testenv:py36-jaeger-pip18]
+alwayscopy = true
+
+[testenv:py36-jaeger-pip19]
 alwayscopy = true
 
 [flake8]


### PR DESCRIPTION
pip 19+ has removed dependency link support: https://pip.pypa.io/en/stable/news/#id4

These changes continue adopting the paths suggested in https://github.com/pypa/pip/issues/4187 (for which I had lost the timeline) and move to full PEP 508 usage with the versioned egg approach.