### PR TITLE
Source Jaeger without tornado and adopt in sfx-py-trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ is provided by the installer:
 ```
 
 **Note: `sfx-py-trace` cannot, at this time, enable auto-instrumentation of Django projects, as the instrumentor
-application must be added to the project settings' installed apps for lazy tracer creation.**
+application must be added to the project settings' installed apps.**
 
 This command line script loader will create a Jaeger tracer instance using the access token specified via
 environment variable or argument to report your spans to SignalFx.  It will then call `auto_instrument()` before

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,7 +162,7 @@ def test_jaeger(session):
 
 
 @nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
-def jaeger_via_bootrap(session):
+def jaeger_via_bootstrap(session):
     # provides coverage for desired version installation via bootstrap
     install_unit_tests(session, 'jaeger-client')
     session.run('sfx-py-trace-bootstrap')
@@ -176,7 +176,7 @@ def jaeger_via_bootrap(session):
 def jaeger_via_extras(session, pip):
     install_unit_tests(session, f'pip{pip}')
 
-    jaeger_extra_args = ['.[jaeger,tornado]']
+    jaeger_extra_args = ['.[jaeger,requests]']
     if pip == '<11':
         jaeger_extra_args.insert(0, '--process-dependency-links')
     session.install(*jaeger_extra_args)

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -2,7 +2,7 @@ dbapi-opentracing
 git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
 git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
 git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
-git+https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender#egg=jaeger-client
+git+https://github.com/signalfx/jaeger-client-python.git@ot_20_http_sender_no_tornado#egg=jaeger-client
 pymongo-opentracing
 git+https://github.com/opentracing-contrib/python-redis.git@v1.0.0#egg=redis-opentracing
 requests-opentracing

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,7 +42,8 @@ run `sfx-py-trace-bootstrap` or installed the required dependencies as package e
  $ SIGNALFX_INGEST_URL='http://localhost:9080/v1/trace' sfx-py-trace my_application.py --app_arg_one --app_arg_two
 ```
 
-Because of our modified Jaeger tracer's Tornado dependency and its known limitations, the `sfx-py-trace` utility is not
-currently a substitute for a system Python executable and must be provided a target Python script or path with a
-`__main__` module. There are plans to remove the Tornado dependency that will allow us to enhance the script runner's
-functionality in other environments and use cases.
+`sfx-py-trace` works by sourcing your organization access token (if provided) and registering an auto-instrumenting
+[`sitecustomize`](https://docs.python.org/3.6/library/site.html) module to your `PYTHONPATH` before invoking your
+target file/module and arguments with the current Python executable.  The `sitecustomize` module will create an instance
+of a Jaeger tracer and set it as the OpenTracing global tracer for all instrumentations to use.  Running this should not
+prevent any existing `sitecustomize` module on your `PYTHONPATH` from also running.

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,7 +13,8 @@ def is_installed(library):
     return library in sys.modules or pkgutil.find_loader(library) is not None
 
 
-jaeger_client = 'https://github.com/signalfx/jaeger-client-python/tarball/ot_20_http_sender#egg=jaeger-client'
+jaeger_client = ('https://github.com/signalfx/jaeger-client-python/tarball/'
+                 'ot_20_http_sender_no_tornado#egg=jaeger-client')
 
 instrumentors = {
     'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',

--- a/scripts/site_/__init__.py
+++ b/scripts/site_/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.

--- a/scripts/site_/sitecustomize.py
+++ b/scripts/site_/sitecustomize.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+from __future__ import print_function
+
+import traceback
+import os.path
+import sys
+
+from signalfx_tracing import auto_instrument, create_tracer
+from signalfx_tracing.utils import get_module
+
+
+access_token = os.environ.get('SIGNALFX_ACCESS_TOKEN')
+
+try:
+    auto_instrument(create_tracer(access_token=access_token, set_global=True))
+except Exception:
+    print(traceback.format_exc())
+
+# Do not prevent existing sitecustomize module import. Done by
+# removing this module's package and attempting to import
+# sitecustomize module.
+
+# Removing references to this sitecustomize module
+# can trigger garbage collection and cause lookup failures in other modules.
+sys.modules['sfx_sitecustomize'] = sys.modules.pop('sitecustomize', None)
+sys.path.remove(os.path.abspath(os.path.dirname(__file__)))
+try:
+    get_module('sitecustomize')
+except ImportError:
+    pass

--- a/tests/integration/lib/runner_target_script.py
+++ b/tests/integration/lib/runner_target_script.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+# Copyright (C) 2018-2019 SignalFx, Inc. All rights reserved.
 from argparse import ArgumentParser
 import sys
 import os
@@ -39,3 +39,5 @@ else:
                         '--three', 'This Is A String', '-i', '1', '2', '3', '4', '5',
                         '-j', '1', '2', '3', '4', '5', '-t', 'collision1', '--token', 'collision2',
                         '--unknown=asdf', '-u' 'file.py', 'file.txt']
+
+    assert sys.modules['my_altered_site'] is True

--- a/tests/integration/sitecustomize.py
+++ b/tests/integration/sitecustomize.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+import sys
+
+sys.modules['my_altered_site'] = True


### PR DESCRIPTION
Updates the provided jaeger to be one without the Tornado dependency: https://github.com/signalfx/jaeger-client-python/tree/ot_20_http_sender_no_tornado.  This allows creation of a tracer in imported modules because all thread creation is deferred until actual tracing activity.

Also provides updates to sfx-py-trace to utilize the `site` library and improve the user experience for Django apps.