### PR TITLE
Add target path for sfx-py-trace-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ per-instrumentor basis, it's highly recommended you use the helpful [bootstrap u
 obtaining and installing any applicable, feature-ready instrumentors along with a compatible tracer:
 
 ```sh
- $ pip install signalfx-tracing
- $ sfx-py-trace-bootstrap
+  $ pip install signalfx-tracing
+  $ sfx-py-trace-bootstrap
 ```
 
 For example, if your environment has Requests and Flask in its Python path, the corresponding OpenTracing
@@ -80,22 +80,31 @@ To run the instrumentor bootstrap process without installing the suggested trace
 project's source tree:
 
 ```sh
- $ scripts/bootstrap.py --deps-only
+  $ scripts/bootstrap.py --deps-only
 ```
 
-It's also possible to install the supported instrumentors as package extras:
+You can also specify a target installation directory, which will include the most recent `signalfx-tracing` as provided
+by PyPI:
+
+```sh
+  $ sfx-py-trace-bootstrap -t /my/site/packages/directory
+```
+
+It's also possible to install the supported instrumentors as package extras from a cloned repository:
 
 ```bash
+  $ git clone https://github.com/signalfx/signalfx-python-tracing.git
   # Supported extras are dbapi, django, flask, pymongo, pymysql, redis, requests, tornado
-  $ pip install 'signalfx-tracing[django,redis,requests]'
+  $ pip install './signalfx-python-tracing[django,redis,requests]'
 ```
 
 **Note: For pip versions earlier than 18.0, it's necessary to include `--process-dependency-links` to
 obtain the desired instrumentor versions.**
 
 ```bash
-   # pip versions <18.0
-   $ pip install --process-dependency-links 'signalfx-tracing[jaeger,tornado]'
+  $ git clone https://github.com/signalfx/signalfx-python-tracing.git
+  # pip versions <18.0
+  $ pip install --process-dependency-links './signalfx-python-tracing[jaeger,tornado]'
 ```
 
 ### Tracer
@@ -108,9 +117,9 @@ ready for reporting to SignalFx. You can obtain an instance of the suggested Jae
   $ sfx-py-trace-bootstrap
 
   # or as package extra
-  $ pip install 'signalfx-tracing[jaeger]'
+  $ pip install './signalfx-python-tracing[jaeger]'
   # please use required --process-dependency-links for pip versions <18.0 
-  $ pip install --process-dependency-links 'signalfx-tracing[jaeger]'
+  $ pip install --process-dependency-links './signalfx-python-tracing[jaeger]'
 
   # or from project source tree, along with applicable instrumentors
   $ scripts/bootstrap.py --jaeger
@@ -173,11 +182,11 @@ automatically instrument your applicable program with the default settings, a he
 is provided by the installer:
 
 ```sh
- $ SIGNALFX_INGEST_URL='http://localhost:9080/v1/trace' sfx-py-trace my_application.py --app_arg_one --app_arg_two
- # not providing an access token assumes usage of the Smart Agent and/or Smart Gateway
- $ SIGNALFX_ACCESS_TOKEN=<OrganizationAccessToken> sfx-py-trace my_application.py --app_arg_one --app_arg_two
- # or
- $ sfx-py-trace --token <OrganizationAccessToken> my_application.py --app_arg_one --app_arg_two
+  $ SIGNALFX_INGEST_URL='http://localhost:9080/v1/trace' sfx-py-trace my_application.py --app_arg_one --app_arg_two
+  # not providing an access token assumes usage of the Smart Agent and/or Smart Gateway
+  $ SIGNALFX_ACCESS_TOKEN=<OrganizationAccessToken> sfx-py-trace my_application.py --app_arg_one --app_arg_two
+  # or
+  $ sfx-py-trace --token <OrganizationAccessToken> my_application.py --app_arg_one --app_arg_two
 ```
 
 **Note: `sfx-py-trace` cannot, at this time, enable auto-instrumentation of Django projects, as the instrumentor

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ except ImportError:
 
 Other package installers are expected to be supported in the future, and if you have one you'd like us to support,
 please feel free to open a GitHub issue.  `sfx-py-trace-bootstrap` is our preferred installation utility, but if you'd
-rather manage your instrumentations manually, we also suggest using the provided
+rather manage your instrumentations manually, we also suggest cloning this repo and using the provided
 [package extras](../README.md#library-and-instrumentors).
 
 

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -44,23 +44,29 @@ packages = {
 }
 
 
-def _install_updated_dependency(library, package_path):
+def _to_target_arg(target=None):
+    return ['-t', target] if target else []
+
+
+def _install_updated_dependency(library, package_path, target=None):
     """
-    Ensures that desired version is installed w/o upgrading its dependencies by uninstalling where necessary.
+    Ensures that desired version is installed w/o upgrading its dependencies by uninstalling where necessary (if
+    `target` is not provided).
 
     OpenTracing-Contrib often has traced library as instrumentation dependency (e.g. Django for django-opentracing),
     so using -I on library will cause likely undesired Django upgrade.  Using --no-dependencies alone would
     leave potential for nonfunctional installations.
     """
-    pip_list = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze']).decode().lower()
-    path = packages[library]
-    if '{}=='.format(path).lower() in pip_list:
-        print('Existing {} installation detected.  Uninstalling.'.format(path))
-        subprocess.check_call([sys.executable, '-m', 'pip', 'uninstall', '-y', path])
+    if not target:
+        pip_list = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze']).decode().lower()
+        path = packages[library]
+        if '{}=='.format(path).lower() in pip_list:
+            print('Existing {} installation detected.  Uninstalling.'.format(path))
+            subprocess.check_call([sys.executable, '-m', 'pip', 'uninstall', '-y', path])
 
     # explicit upgrade strategy to override potential pip config
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-U',
-                           '--upgrade-strategy', 'only-if-needed', package_path])
+                           '--upgrade-strategy', 'only-if-needed', package_path] + _to_target_arg(target))
     _pip_check()
 
 
@@ -83,27 +89,38 @@ def _pip_check():
             raise RuntimeError('Dependency conflict found: {}'.format(pip_check))
 
 
-def install_jaeger():
+def install_jaeger(target=None):
     print('Installing Jaeger Client.')
-    _install_updated_dependency('jaeger', jaeger_client)
+    _install_updated_dependency('jaeger', jaeger_client, target)
 
 
-def install_deps():
+def install_deps(target=None):
     for library, instrumentor in instrumentors.items():
         if is_installed(library):
             print('Installing {} instrumentor.'.format(library))
-            _install_updated_dependency(library, instrumentor)
+            _install_updated_dependency(library, instrumentor, target)
 
 
-def install_sfx_py_trace():
+def install_sfx_py_trace(target=None):
     cwd = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
     print('Installing SignalFx-Tracing.')
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-I', cwd])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-I', cwd] + _to_target_arg(target))
+
+
+target_help = ('The value to provide pip for --target: "Install packages into <dir>.". '
+               'Will trigger additional signalfx-tracing installation from PyPI to target.')
 
 
 def console_script():
-    install_jaeger()
-    install_deps()
+    ap = ArgumentParser()
+    ap.add_argument('-t', '--target', help=target_help)
+    args = ap.parse_args()
+
+    if args.target:
+        _install_updated_dependency('signalfx-tracing', 'signalfx-tracing', args.target)
+
+    install_jaeger(args.target)
+    install_deps(args.target)
 
 
 def main():
@@ -111,17 +128,18 @@ def main():
     ap.add_argument('--jaeger', action='store_true')
     ap.add_argument('--jaeger-only', action='store_true')
     ap.add_argument('--deps-only', action='store_true')
+    ap.add_argument('-t', '--target', help=target_help)
     args = ap.parse_args()
 
     if args.jaeger or args.jaeger_only:
-        install_jaeger()
+        install_jaeger(args.target)
         if args.jaeger_only:
             return
 
-    install_deps()
+    install_deps(args.target)
 
     if not args.deps_only:
-        install_sfx_py_trace()
+        install_sfx_py_trace(args.target)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For supporting custom site packages targets or when building a Lambda function environment, it can be helpful to specify the target destination for instrumentations and dependencies.  These changes introduce a `-t` argument to `sfx-py-trace-bootstrap` and the bootstrap script to pass to the underlying pip command.

Also pork barreling package extras installation path to only work w/ cloned repositories and PyPI blocks this in newer pip versions.