### PR TITLE
Provide instrumentation env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ def untraced_route():
     return 'Goodbye!'
 ```
 
+**Note: Both `instrument()` and `auto_instrument()` invocations can be converted to no-ops if the
+`SIGNALFX_TRACING_ENABLED` environment variable is set to `False` or `0`.  This can be helpful when developing your
+auto-instrumented application locally or in test environments.**
+
 ## Supported Frameworks and Libraries
 
 * [Django 1.8+](./signalfx_tracing/libraries/django_/README.md) - `instrument(django=True)`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,3 +47,6 @@ run `sfx-py-trace-bootstrap` or installed the required dependencies as package e
 target file/module and arguments with the current Python executable.  The `sitecustomize` module will create an instance
 of a Jaeger tracer and set it as the OpenTracing global tracer for all instrumentations to use.  Running this should not
 prevent any existing `sitecustomize` module on your `PYTHONPATH` from also running.
+
+**Node: `sfx-py-trace` functionality will be disabled if the `SIGNALFX_TRACING_ENABLED` environment variable is `False`
+or `0`.  It can still be used as an application runner, but its `site` module usage will be bypassed.**

--- a/scripts/sfx_py_trace.py
+++ b/scripts/sfx_py_trace.py
@@ -5,6 +5,7 @@ import os.path
 import sys
 import os
 
+from signalfx_tracing import utils
 
 ap = ArgumentParser()
 ap.add_argument('--token', '-t', required=False, type=str, dest='token',
@@ -18,9 +19,10 @@ def main():
     if args.token:
         os.environ['SIGNALFX_ACCESS_TOKEN'] = args.token
 
-    site_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'site_')
-    py_path = os.environ.get('PYTHONPATH', '')
-    os.environ['PYTHONPATH'] = site_dir + os.pathsep + py_path if py_path else site_dir
+    if utils.is_truthy(os.environ.get('SIGNALFX_TRACING_ENABLED', True)):
+        site_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'site_')
+        py_path = os.environ.get('PYTHONPATH', '')
+        os.environ['PYTHONPATH'] = site_dir + os.pathsep + py_path if py_path else site_dir
 
     # provide the target file as well as follow posix convention
     # that first argv item should be the executable filename

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -12,6 +12,14 @@ import opentracing
 from .constants import instrumented_attr
 
 
+# Accepted case-insensitive disabling environment variable values
+_falsy = ('0', '0.0', 'f', 'false', 'n', 'no')
+
+
+def is_truthy(value):
+    return bool(value) and str(value).lower() not in _falsy
+
+
 def get_module(library):
     if library not in sys.modules:
         importlib.import_module(library)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -72,3 +72,11 @@ def test_revert_wrapper():
 
     utils.revert_wrapper(Namespace, 'wrappee')
     assert Namespace().wrappee() == 'wrappee'
+
+
+def test_is_truthy():
+    for val in (False, None, 0, [], (), {}, set(), 'FaLsE', 'f', 'F', 'No', 'n', 'N', '', b''):
+        assert utils.is_truthy(val) is False
+
+    for val in (True, 'y', 1, 'asdf', [1], (1,), {'one': 1}, set([1])):
+        assert utils.is_truthy(val) is True


### PR DESCRIPTION
For cases where users don't want to initiate instrumentation without having to modify their code or run configuration, these changes introduce `SIGNALFX_TRACING_ENABLED` as a bypass mechanism.