### PR TITLE
Include 3.7 in testing and improve nox performance

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,8 @@
 import subprocess
 import tempfile
 import shutil
+import os
+import re
 
 import nox
 
@@ -9,8 +11,30 @@ import nox
 pytest = 'pytest<4.2'  # https://github.com/pytest-dev/pytest-django/issues/698
 
 
+sdist = None
+
+
+def build(session):
+    global sdist
+    if sdist is not None:
+        return
+
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(cwd, 'signalfx_tracing/__init__.py')) as init_file:
+        match = re.search("__version__ = ['\"]([^'\"]*)['\"]", init_file.read())
+        if not match:
+            raise RuntimeError('Not able to determine current version')
+    version = match.group(1)
+
+    session.run('python', 'setup.py', 'sdist')
+    files = [f for f in os.listdir('dist') if version in f]
+    assert len(files) == 1
+    sdist = f'dist/{files.pop()}'
+
+
 def install_unit_tests(session, *other_packaages):
-    return session.install(pytest, '.[unit_tests]', *other_packaages)
+    build(session)
+    return session.install(pytest, f'{sdist}[unit_tests]', *other_packaages)
 
 
 def pip_check(session):
@@ -28,16 +52,17 @@ def flake8(session):
     session.run('flake8', 'setup.py', 'scripts', 'signalfx_tracing', 'tests', 'noxfile.py')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def unit(session):
     install_unit_tests(session)
     pip_freeze(session)
     session.run('pytest', 'tests/unit', '--ignore', 'tests/unit/libraries', '-p', 'no:django')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def bootstrap_with_target(session):
-    session.install('.')
+    build(session)
+    session.install(sdist)
     dir = tempfile.mkdtemp()
     session.run('sfx-py-trace-bootstrap', '-t', dir)
     target_dir = subprocess.run(['ls', dir], stdout=subprocess.PIPE).stdout.decode()
@@ -51,7 +76,7 @@ def test_django(session):
     session.run('pytest', 'tests/integration/django_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def django18_via_bootstrap(session):
     # provides coverage for desired version installation via bootstrap
     install_unit_tests(session, 'django>=1.8,<1.9', 'pytest-django', 'django-opentracing')
@@ -61,12 +86,12 @@ def django18_via_bootstrap(session):
     test_django(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('pip', ('<11', '>=18,<19', '>=19,<20'))
 def django18_via_extras(session, pip):
     install_unit_tests(session, f'pip{pip}', 'django>=1.8,<1.9', 'pytest-django')
 
-    django_extra_args = ['.[django]']
+    django_extra_args = [f'{sdist}[django]']
     if pip == '<11':
         django_extra_args.insert(0, '--process-dependency-links')
     session.install(*django_extra_args)
@@ -76,26 +101,29 @@ def django18_via_extras(session, pip):
     test_django(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('django', ('>=1.9,<1.10', '>=1.10,<1.11', '>=1.11,<1.12'))
 def django19_110_111_via_extras(session, django):
-    install_unit_tests(session, f'django{django}', 'pytest-django', '.[django]')
+    install_unit_tests(session, f'django{django}', 'pytest-django')
+    session.install(f'{sdist}[django]')
     pip_check(session)
     pip_freeze(session)
     test_django(session)
 
 
-@nox.session(python=('3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def django20_via_extras(session):
-    install_unit_tests(session, 'django>=2.0,<2.1', 'pytest-django', '.[django]')
+    install_unit_tests(session, 'django>=2.0,<2.1', 'pytest-django')
+    session.install(f'{sdist}[django]')
     pip_check(session)
     pip_freeze(session)
     test_django(session)
 
 
-@nox.session(python=('3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('3.5', '3.6', '3.7'), reuse_venv=True)
 def django21_via_extras(session):
-    install_unit_tests(session, 'django>=2.1,<2.2', 'pytest-django', '.[django]')
+    install_unit_tests(session, 'django>=2.1,<2.2', 'pytest-django')
+    session.install(f'{sdist}[django]')
     pip_check(session)
     pip_freeze(session)
     test_django(session)
@@ -106,28 +134,31 @@ def test_elasticsearch(session, image_version):
     session.run('pytest', '--elasticsearch-image-version', image_version, 'tests/integration/elasticsearch_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('elasticsearch', ('>=2.0,<2.1', '>=2.1,<2.2', '>=2.2,<2.3', '>=2.3,<2.4', '>=2.4,<2.5'))
 def elasticsearch2_via_extras(session, elasticsearch):
-    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker', '.[elasticsearch]')
+    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker')
+    session.install(f'{sdist}[elasticsearch]')
     pip_check(session)
     pip_freeze(session)
     test_elasticsearch(session, '2.4.6')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('elasticsearch', ('>=5.0,<5.1', '>=5.1,<5.2', '>=5.2,<5.3', '>=5.3,<5.4', '>=5.4,<5.5', '>=5.5,<5.6'))
 def elasticsearch5_via_extras(session, elasticsearch):
-    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker', '.[elasticsearch]')
+    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker')
+    session.install(f'{sdist}[elasticsearch]')
     pip_check(session)
     pip_freeze(session)
     test_elasticsearch(session, '5.6.14')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('elasticsearch', ('>=6.0,<6.1', '>=6.1,<6.2', '>=6.2,<6.3', '>=6.3,<6.4'))
 def elasticsearch6i_via_extras(session, elasticsearch):
-    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker', '.[elasticsearch]')
+    install_unit_tests(session, f'elasticsearch{elasticsearch}', 'docker')
+    session.install(f'{sdist}[elasticsearch]')
     pip_check(session)
     pip_freeze(session)
     test_elasticsearch(session, '6.5.4')
@@ -138,7 +169,7 @@ def test_flask(session):
     session.run('pytest', 'tests/integration/flask_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def flask010_via_bootstrap(session):
     # provides coverage for desired version installation via bootstrap
     install_unit_tests(session, 'flask>=0.10,<0.11', 'requests', 'flask-opentracing')
@@ -148,11 +179,11 @@ def flask010_via_bootstrap(session):
     test_flask(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('pip', ('<11', '>=18,<19', '>=19,<20'))
 def flask010_via_extras(session, pip):
     install_unit_tests(session, f'pip{pip}', 'flask>=0.10,<0.11', 'requests')
-    flask_extra_args = ['.[flask]']
+    flask_extra_args = [f'{sdist}[flask]']
     if pip == '<11':
         flask_extra_args.insert(0, '--process-dependency-links')
     session.install(*flask_extra_args)
@@ -162,10 +193,11 @@ def flask010_via_extras(session, pip):
     test_flask(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('flask', ('>=0.11,<0.12', '>=0.12,<0.13', '>=1.0,<1.1'))
 def flask_via_extras(session, flask):
-    install_unit_tests(session, f'flask{flask}', 'requests', '.[flask]')
+    install_unit_tests(session, f'flask{flask}', 'requests')
+    session.install(f'{sdist}[flask]')
     pip_check(session)
     pip_freeze(session)
     test_flask(session)
@@ -176,7 +208,7 @@ def test_jaeger(session):
     session.run('pytest', 'tests/integration/test_runner.py')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def jaeger_via_bootstrap(session):
     # provides coverage for desired version installation via bootstrap
     install_unit_tests(session, 'jaeger-client')
@@ -186,12 +218,12 @@ def jaeger_via_bootstrap(session):
     test_jaeger(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('pip', ('<11', '>=18,<19', '>=19,<20'))
 def jaeger_via_extras(session, pip):
     install_unit_tests(session, f'pip{pip}')
 
-    jaeger_extra_args = ['.[jaeger,requests]']
+    jaeger_extra_args = [f'{sdist}[jaeger,requests]']
     if pip == '<11':
         jaeger_extra_args.insert(0, '--process-dependency-links')
     session.install(*jaeger_extra_args)
@@ -201,38 +233,42 @@ def jaeger_via_extras(session, pip):
     test_jaeger(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def psycopg2_via_extras(session):
-    install_unit_tests(session, 'psycopg2>=2.7,<2.8', 'docker', '.[psycopg2]')
+    install_unit_tests(session, 'psycopg2>=2.7,<2.8', 'docker')
+    session.install(f'{sdist}[psycopg2]')
     session.run('pytest', 'tests/unit/libraries/psycopg2_')
     session.run('pytest', 'tests/integration/psycopg2_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('pymongo', ('>=3.1,<3.2', '>=3.2,<3.3', '>=3.3,<3.4', '>=3.4,<3.5',
                              '>=3.5,<3.6', '>=3.6,<3.7', '>=3.7,<3.8'))
 def pymongo_via_extras(session, pymongo):
-    install_unit_tests(session, 'pymongo{pymongo}', 'docker', 'mockupdb', '.[pymongo]')
+    install_unit_tests(session, f'pymongo{pymongo}', 'docker', 'mockupdb')
+    session.install(f'{sdist}[pymongo]')
     session.run('pytest', 'tests/unit/libraries/pymongo_')
     session.run('pytest', 'tests/integration/pymongo_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('pymysql', ('>=0.8,<0.9', '>=0.9,<0.10'))
 def pymysql_via_extras(session, pymysql):
-    install_unit_tests(session, f'pymysql{pymysql}', 'docker', '.[pymysql]')
+    install_unit_tests(session, f'pymysql{pymysql}', 'docker')
+    session.install(f'{sdist}[pymysql]')
     session.run('pytest', 'tests/unit/libraries/pymysql_')
     session.run('pytest', 'tests/integration/pymysql_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def redis_via_extras(session):
-    install_unit_tests(session, f'redis>=2.10,<2.11', 'docker', '.[redis]')
+    install_unit_tests(session, f'redis>=2.10,<2.11', 'docker')
+    session.install(f'{sdist}[redis]')
     session.run('pytest', 'tests/unit/libraries/redis_')
     session.run('pytest', 'tests/integration/redis_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('requests', ('>=2.0,<2.1', '>=2.10,<2.11', '>=2.11,<2.12', '>=2.12,<2.13',
                               '>=2.13,<2.14', '>=2.14,<2.15', '>=2.15,<2.16', '>=2.16,<2.17',
                               '>=2.17,<2.18', '>=2.18,<2.19', '>=2.19,<2.20', '>=2.20,<2.21',
@@ -240,14 +276,16 @@ def redis_via_extras(session):
                               '>=2.4,<2.5', '>=2.5,<2.6', '>=2.6,<2.7', '>=2.7,<2.8',
                               '>=2.8,<2.9', '>=2.9,<2.10'))
 def requests_via_extras(session, requests):
-    install_unit_tests(session, f'requests{requests}', 'docker', '.[requests]')
+    install_unit_tests(session, f'requests{requests}', 'docker')
+    session.install(f'{sdist}[requests]')
     session.run('pytest', 'tests/unit/libraries/requests_')
     session.run('pytest', 'tests/integration/requests_')
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6'), reuse_venv=True)
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('tornado', ('>=4.3,<4.4', '>=4.4,<4.5', '>=4.5,<5.0', '>=5.0,<5.1', '>=5.1,<5.2'))
 def tornado_via_extras(session, tornado):
-    install_unit_tests(session, f'tornado{tornado}', 'requests', '.[tornado]')
+    install_unit_tests(session, f'tornado{tornado}', 'requests')
+    session.install(f'{sdist}[tornado]')
     session.run('pytest', 'tests/unit/libraries/tornado_')
     session.run('pytest', 'tests/integration/tornado_')

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ from setuptools.command.test import test as TestCommand
 from setuptools import setup, find_packages
 import sys
 import os
-
-version = '0.0.7'
+import re
 
 
 protocols = ('http://', 'https://', 'ssh://', 'svn://')
@@ -108,6 +107,14 @@ with open(os.path.join(cwd, 'requirements-inst.txt')) as inst_requirements_file:
 with open(os.path.join(cwd, 'README.md')) as readme_file:
     long_description = readme_file.read()
 
+version = None
+with open(os.path.join(cwd, 'signalfx_tracing/__init__.py')) as init_file:
+    match = re.search("__version__ = ['\"]([^'\"]*)['\"]", init_file.read())
+    if not match:
+        raise RuntimeError('Not able to determine current version in signalfx_tracing/__init__.py')
+    version = match.group(1)
+
+
 unit_test_requirements = ['mock', 'pytest', 'six']
 
 setup_args = dict(
@@ -133,6 +140,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     packages=find_packages(),
     install_requires=requirements,

--- a/signalfx_tracing/__init__.py
+++ b/signalfx_tracing/__init__.py
@@ -2,5 +2,7 @@
 from .instrumentation import instrument, uninstrument, auto_instrument  # noqa
 from .utils import create_tracer, trace  # noqa
 
+__version__ = '0.0.7'
+
 # Django
 default_app_config = 'signalfx_tracing.libraries.django_.apps.SignalFxConfig'  # noqa


### PR DESCRIPTION
These changes add python 3.7 to the tested versions and have the nox session build an sdist to install from over pip installing from the directory with an increasing .nox directory to comb through: https://github.com/pypa/pip/issues/2195.  Tox allowed us to copy sources to the venv before local installations but nox is without that functionality.  This is workaround also provides some build sanity in the process.