### PR TITLE
Update Psycopg instrumentor

### DIFF
--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,4 +1,4 @@
-dbapi-opentracing
+dbapi-opentracing>=0.0.3
 git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
 git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
 git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -21,9 +21,9 @@ instrumentors = {
     'elasticsearch': ('https://github.com/signalfx/python-elasticsearch/tarball/2.0_support_multiple_versions'
                       '#egg=elasticsearch-opentracing'),
     'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
-    'psycopg2': 'dbapi-opentracing',
+    'psycopg2': 'dbapi-opentracing>=0.0.3',
     'pymongo': 'pymongo-opentracing',
-    'pymysql': 'dbapi-opentracing',
+    'pymysql': 'dbapi-opentracing>=0.0.3',
     'redis': 'https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing',
     'requests': 'requests-opentracing',
     'tornado': 'tornado-opentracing==1.0.1'

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -25,8 +25,12 @@ def is_truthy(value):
 
 
 def get_module(library):
+    """Attempts import a library by name, returning None if not available"""
     if library not in sys.modules:
-        importlib.import_module(library)
+        try:
+            importlib.import_module(library)
+        except ImportError:
+            return None
     return sys.modules[library]
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,6 +20,10 @@ def test_get_module_imports_unimported_modules():
             import logging
 
 
+def test_get_module_is_none_for_unavailable_modules():
+    assert utils.get_module('not_a_real_module_12345') is None
+
+
 def test_mark_instrumented_and_uninstrumented():
     class MockModule(object):
         pass


### PR DESCRIPTION
These changes adopt dbapi-opentracing's new Psycopg connection_factory functionality: https://github.com/opentracing-contrib/python-dbapi/pull/2.  This ensures that auto-instrumented connection instances are compatible w/ the psycopg2 C extensions overall.

Also silences ImportErrors from `get_module`, which is useful for not failing on instrument() calls without proper instrumentation libs.