### PR TITLE
Reset sitecustomize module to sfx-py-trace's

### DIFF
--- a/scripts/site_/sitecustomize.py
+++ b/scripts/site_/sitecustomize.py
@@ -24,7 +24,8 @@ except Exception:
 # can trigger garbage collection and cause lookup failures in other modules.
 sys.modules['sfx_sitecustomize'] = sys.modules.pop('sitecustomize', None)
 sys.path.remove(os.path.abspath(os.path.dirname(__file__)))
-try:
-    get_module('sitecustomize')
-except ImportError:
-    pass
+
+# Attempt to load any existing sitecustomize
+module = get_module('sitecustomize')
+if module is None:  # reset to our own if no preexisting
+    sys.modules['sitecustomize'] = sys.modules['sfx_sitecustomize']

--- a/tests/integration/lib/runner_target_script.py
+++ b/tests/integration/lib/runner_target_script.py
@@ -23,6 +23,8 @@ else:
     ap.add_argument('-t', dest='t', type=str)
     ap.add_argument('--token', dest='token', type=str)
 
+    ap.add_argument('--sitecustomize', dest='sitecustomize', action='store_true')
+
     known, unknown = ap.parse_known_args()
 
     assert known.one == 123
@@ -35,9 +37,13 @@ else:
     assert known.token == 'collision2'
     assert unknown == ['--unknown=asdf', '-u' 'file.py', 'file.txt']
 
-    assert sys.argv == [os.path.abspath(__file__), '--one', '123', '--two', '123.456',
-                        '--three', 'This Is A String', '-i', '1', '2', '3', '4', '5',
-                        '-j', '1', '2', '3', '4', '5', '-t', 'collision1', '--token', 'collision2',
-                        '--unknown=asdf', '-u' 'file.py', 'file.txt']
+    expected_args = [os.path.abspath(__file__), '--one', '123', '--two', '123.456',
+                     '--three', 'This Is A String', '-i', '1', '2', '3', '4', '5',
+                     '-j', '1', '2', '3', '4', '5', '-t', 'collision1', '--token', 'collision2',
+                     '--unknown=asdf', '-u' 'file.py', 'file.txt']
 
-    assert sys.modules['my_altered_site'] is True
+    if known.sitecustomize:
+        expected_args += ['--sitecustomize']
+    assert sys.argv == expected_args
+
+    assert sys.modules.get('my_altered_site', False) is known.sitecustomize


### PR DESCRIPTION
In cases where there is no preexisting sitecustomize module in python 3, sfx-py-trace will leak:

```
Failed to import the site module
...
 File "frozen importlib._bootstrap", line 660, in _load_unlocked
KeyError: 'sitecustomize'
```

These changes restore our sitecustomize where no additional is provided.