### PR TITLE
Add db.instance tag to pymysql and psycopg2

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -233,12 +233,25 @@ def jaeger_via_extras(session, pip):
     test_jaeger(session)
 
 
-@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
-def psycopg2_via_extras(session):
-    install_unit_tests(session, 'psycopg2>=2.7,<2.8', 'docker')
-    session.install(f'{sdist}[psycopg2]')
+def test_psycopg(session):
     session.run('pytest', 'tests/unit/libraries/psycopg2_')
     session.run('pytest', 'tests/integration/psycopg2_')
+
+
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
+@nox.parametrize('psycopg2', ('>=2.7,<2.8', '>=2.8,<2.9'))
+def psycopg2_via_extras(session, psycopg2):
+    install_unit_tests(session, f'psycopg2{psycopg2}', 'docker')
+    session.install(f'{sdist}[psycopg2]')
+    test_psycopg(session)
+
+
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
+@nox.parametrize('psycopg2', ('>=2.7,<2.8', '>=2.8,<2.9'))
+def psycopg2_binary_via_extras(session, psycopg2):
+    install_unit_tests(session, f'psycopg2-binary{psycopg2}', 'docker')
+    session.install(f'{sdist}[psycopg2]')
+    test_psycopg(session)
 
 
 @nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,4 +1,4 @@
-dbapi-opentracing>=0.0.3
+dbapi-opentracing>=0.0.4
 git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
 git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
 git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 opentracing>=2.0,<2.1
+six
 wrapt

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -21,9 +21,9 @@ instrumentors = {
     'elasticsearch': ('https://github.com/signalfx/python-elasticsearch/tarball/2.0_support_multiple_versions'
                       '#egg=elasticsearch-opentracing'),
     'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
-    'psycopg2': 'dbapi-opentracing>=0.0.3',
+    'psycopg2': 'dbapi-opentracing>=0.0.4',
     'pymongo': 'pymongo-opentracing',
-    'pymysql': 'dbapi-opentracing>=0.0.3',
+    'pymysql': 'dbapi-opentracing>=0.0.4',
     'redis': 'https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing',
     'requests': 'requests-opentracing',
     'tornado': 'tornado-opentracing==1.0.1'

--- a/signalfx_tracing/libraries/pymysql_/instrument.py
+++ b/signalfx_tracing/libraries/pymysql_/instrument.py
@@ -3,6 +3,7 @@ import logging
 
 from wrapt import wrap_function_wrapper
 from opentracing.ext import tags
+from six import ensure_str
 import opentracing
 
 from signalfx_tracing import utils
@@ -45,6 +46,9 @@ def instrument(tracer=None):
             traced_commands_kwargs[flag] = True
 
         span_tags = {tags.DATABASE_TYPE: 'MySQL'}
+        if connection.db is not None:
+            span_tags[tags.DATABASE_INSTANCE] = ensure_str(connection.db)
+
         if config.span_tags is not None:
             span_tags.update(config.span_tags)
 

--- a/tests/integration/psycopg2_/test_instrumented_connection.py
+++ b/tests/integration/psycopg2_/test_instrumented_connection.py
@@ -74,11 +74,14 @@ class TestInstrumentedConnection(object):
             conn.commit()
         spans = tracer.finished_spans()
         assert len(spans) == 4
+        for span in spans[:3]:
+            assert span.tags['some'] == 'tag'
+            assert span.tags[tags.DATABASE_TYPE] == 'PostgreSQL'
+            assert span.tags[tags.DATABASE_INSTANCE] == 'test_db'
+
         first, second, commit, parent = spans
         for span in (first, second):
             assert span.operation_name == 'DictCursor.execute(insert)'
-            assert span.tags['some'] == 'tag'
-            assert span.tags[tags.DATABASE_TYPE] == 'PostgreSQL'
             assert span.tags['db.rows_produced'] == 1
             assert span.parent_id == parent.context.span_id
             assert tags.ERROR not in span.tags

--- a/tests/integration/pymysql_/test_instrumented_connection.py
+++ b/tests/integration/pymysql_/test_instrumented_connection.py
@@ -68,11 +68,14 @@ class TestInstrumentedConnection(object):
             conn.commit()
         spans = tracer.finished_spans()
         assert len(spans) == 4
+        for span in spans[:3]:
+            assert span.tags['some'] == 'tag'
+            assert span.tags[tags.DATABASE_TYPE] == 'MySQL'
+            assert span.tags[tags.DATABASE_INSTANCE] == 'test_db'
+
         first, second, commit, parent = spans
         for span in (first, second):
             assert span.operation_name == 'DictCursor.execute(insert)'
-            assert span.tags['some'] == 'tag'
-            assert span.tags[tags.DATABASE_TYPE] == 'MySQL'
             assert span.tags['db.rows_produced'] == 1
             assert span.parent_id == parent.context.span_id
             assert tags.ERROR not in span.tags

--- a/tests/unit/libraries/psycopg2_/test_psycopg2.py
+++ b/tests/unit/libraries/psycopg2_/test_psycopg2.py
@@ -50,6 +50,9 @@ class MockDBAPIConnection(object):
     def cursor(self):
         return MockDBAPICursor()
 
+    def get_dsn_parameters(self):
+        return dict(dbname='test')
+
     def __exit__(self, exc, value, tb):
         if exc:
             return self.rollback()
@@ -90,6 +93,8 @@ class TestPsycopg2(Psycopg2TestSuite):
                 assert len(spans) == 3
                 for span in spans:
                     assert span.tags[tags.DATABASE_TYPE] == 'PostgreSQL'
+                    assert span.tags[tags.DATABASE_INSTANCE] == 'test'
+
                 assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
                 assert spans[1].operation_name == 'MockDBAPICursor.executemany(traced)'
                 assert spans[2].operation_name == 'MockDBAPICursor.callproc(traced)'

--- a/tests/unit/libraries/pymysql_/test_pymysql.py
+++ b/tests/unit/libraries/pymysql_/test_pymysql.py
@@ -42,6 +42,8 @@ class MockDBAPIConnection(Mock):
     rollback = MagicMock(spec=types.MethodType)
     rollback.__name__ = 'rollback'
 
+    db = 'test_db'
+
     def cursor(self):
         return MockDBAPICursor()
 
@@ -86,6 +88,8 @@ class TestPyMySQL(PyMySQLTestSuite):
                 assert len(spans) == 3
                 for span in spans:
                     assert span.tags[tags.DATABASE_TYPE] == 'MySQL'
+                    assert span.tags[tags.DATABASE_INSTANCE] == connection.db
+
                 assert spans[0].operation_name == 'MockDBAPICursor.execute(traced)'
                 assert spans[1].operation_name == 'MockDBAPICursor.executemany(traced)'
                 assert spans[2].operation_name == 'MockDBAPICursor.callproc(traced)'
@@ -235,3 +239,5 @@ class TestPyMySQLConfig(PyMySQLTestSuite):
                 assert spans[2].operation_name == 'MockDBAPIConnection.commit()'
                 for span in spans:
                     assert span.tags['custom'] == 'tag'
+                    assert span.tags[tags.DATABASE_TYPE] == 'MySQL'
+                    assert span.tags[tags.DATABASE_INSTANCE] == connection.db


### PR DESCRIPTION
Also updates dbapi version to pull in `span.kind` addition and expands compatibility testing.