### PR TITLE
Provide instrumentation-disabling env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ statement (see: [Python threading doc](https://docs.python.org/2/library/threadi
 Because of this issue, and for general lack of HTTP reporting support, we highly suggest you use our modified [Jaeger
 tracer](#Tracer) that provides deferred thread creation to avoid this constraint.
 
+The application runner will by default attempt to instrument all available libraries for which there are corresponding
+instrumentations installed on your system.  If you would like to prevent the tracing of particular libraries at run time,
+you can set the `SIGNALFX_<LIBRARY_NAME>_ENABLED=False` environment variables when launching the `sfx-py-trace` process.
+For example, to prevent auto-instrumentation of Tornado, you could run:
+
+```sh
+  $ SIGNALFX_TORNADO_ENABLED=False sfx-py-trace my_application.py
+```
+
+The supported value of each library name is the uppercase form of the corresponding `instrument()`
+[keyword argument](#Supported-Frameworks-and-Libraries).
+
 ### Trace Decorator
 Not all applications follow the basic architectural patterns allowed by their frameworks, and no single tool will be
 able to represent all use cases without user input.  To meaningfully unite isolated traces into a single, more

--- a/noxfile.py
+++ b/noxfile.py
@@ -223,8 +223,9 @@ def test_jaeger(session):
 
 @nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def jaeger_via_bootstrap(session):
-    # provides coverage for desired version installation via bootstrap
-    install_unit_tests(session, 'jaeger-client', 'sfx-jaeger-client')
+    # provides coverage for desired version installation via bootstrap.
+    # pinning Tornado dep to that w/ stack_context.  Should remove w/ Tornado 6 support.
+    install_unit_tests(session, 'tornado==5.1.1', 'jaeger-client', 'sfx-jaeger-client')
     session.run('sfx-py-trace-bootstrap')
     pip_check(session)
     pip_freeze(session)

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -50,6 +50,11 @@ def mark_uninstrumented(module):
         pass
 
 
+def instrumentation_disabled(library):
+    env_var = _get_env_var('SIGNALFX_{}_ENABLED'.format(library.upper()), True)
+    return not is_truthy(env_var)
+
+
 class Config(object):
     """A basic namespace"""
 


### PR DESCRIPTION
These changes* add the ability to prevent specific instrumentations by setting an environment variable (`SIGNALFX_<LIBRARY>_ENABLED=false`) as opposed to the current method using filtered `instrument()` calls.  They also begin to log instrumentation application errors from the main `instrument()` helper function instead of raising them.

edit: also including a workaround to the CI failure re: Tornado 6 incompatibility.