### PR TITLE
Add support for Tornado6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,129 @@ jobs:
         name: Extras
         command: python3.7 -m nox -s jaeger_via_extras
 
+  nox_all:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: All Nox 
+        command: python3.7 -m nox
+
+  tornado:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Tornado Legacy 
+        command: python3.7 -m nox -k tornado
+
+  requests:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Requests 
+        command: python3.7 -m nox -k requests
+
+  redis:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Redis 
+        command: python3.7 -m nox -k redis
+
+  pymysql:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: PyMysql 
+        command: python3.7 -m nox -k pymysql
+
+  pymongo:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: PyMongo
+        command: python3.7 -m nox -k pymongo
+
+  psycopg2:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Psycopg2
+        command: python3.7 -m nox -k psycopg2
+
+  flask:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Flask 
+        command: python3.7 -m nox -k flask
+
+  django:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Django
+        command: python3.7 -m nox -k django
+
+  celery:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: Celery 
+        command: python3.7 -m nox -k celery 
+
+  elasticsearch:
+    <<: *pyenv
+    steps:
+    - checkout
+    - *pyenv-versions
+    - *pyenv-set-local
+    - *install-nox
+    - run:
+        name: ElasticSearch 
+        command: python3.7 -m nox -k elasticsearch 
+
+
+
 workflows:
   version: 2
   build:
@@ -69,6 +192,15 @@ workflows:
       - lint
       - unit
       - jaeger_bootstrap
+      - tornado
+      - requests
+      - redis
+      - pymongo
+      - pymysql
+      - flask
+      - django
+      - celery
+
   nightly:
     triggers:
       - schedule:
@@ -82,3 +214,14 @@ workflows:
       - unit
       - jaeger_bootstrap
       - jaeger_extras
+      - lint
+      - unit
+      - jaeger_bootstrap
+      - tornado
+      - requests
+      - redis
+      - pymongo
+      - pymysql
+      - flask
+      - django
+      - celery

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .python-version
 .nox
 .tox
+.vscode
+venv/
+env/
 build/
 dist/
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ auto-instrumented application locally or in test environments.**
 * [PyMySQL 0.8+](./signalfx_tracing/libraries/pymysql_/README.md) - `instrument(pymysql=True)`
 * [Redis-Py 2.10+](./signalfx_tracing/libraries/redis_/README.md) - `instrument(redis=True)`
 * [Requests 2.0+](./signalfx_tracing/libraries/requests_/README.md) - `instrument(requests=True)`
-* [Tornado 4.3-5.x](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`
+* [Tornado 4.3-6.x](./signalfx_tracing/libraries/tornado_/README.md) - `instrument(tornado=True)`
 
 ## Installation and Configuration
 
@@ -152,7 +152,7 @@ tracer = create_tracer(set_global=False)
 
 All other `create_tracer()` arguments are those that can be passed to a `jaeger_client.Config` constructor:
 ```python
-from opentracing.scope_managers.tornado import TornadoScopeManager
+from tornado_opentracing.scope_managers import TornadoScopeManager
 from signalfx_tracing import create_tracer
 
 tracer = create_tracer(

--- a/noxfile.py
+++ b/noxfile.py
@@ -223,9 +223,7 @@ def test_jaeger(session):
 
 @nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def jaeger_via_bootstrap(session):
-    # provides coverage for desired version installation via bootstrap.
-    # pinning Tornado dep to that w/ stack_context.  Should remove w/ Tornado 6 support.
-    install_unit_tests(session, 'tornado==5.1.1', 'jaeger-client', 'sfx-jaeger-client')
+    install_unit_tests(session, 'jaeger-client', 'sfx-jaeger-client')
     session.run('sfx-py-trace-bootstrap')
     pip_check(session)
     pip_freeze(session)
@@ -311,9 +309,19 @@ def requests_via_extras(session, requests):
     session.run('pytest', 'tests/integration/requests_')
 
 
+@nox.session(python=('3.5', '3.6', '3.7'), reuse_venv=True)
+@nox.parametrize('tornado', ('>=6.0,<7.0'))
+def tornado_via_extras(session, tornado):
+    _tornado_via_extras(session, tornado)
+
+
 @nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 @nox.parametrize('tornado', ('>=4.3,<4.4', '>=4.4,<4.5', '>=4.5,<5.0', '>=5.0,<5.1', '>=5.1,<5.2'))
-def tornado_via_extras(session, tornado):
+def tornado_legacy_via_extras(session, tornado):
+    _tornado_via_extras(session, tornado)
+
+
+def _tornado_via_extras(session, tornado):
     install_unit_tests(session, f'tornado{tornado}', 'requests')
     session.install(f'{sdist}[tornado]')
     session.run('pytest', 'tests/unit/libraries/tornado_')

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -1,10 +1,10 @@
 celery-opentracing
 dbapi-opentracing>=0.0.4
-git+https://github.com/signalfx/python-django.git@django_2_ot_2_jaeger#egg=django-opentracing
-git+https://github.com/signalfx/python-elasticsearch.git@2.0_support_multiple_versions#egg=elasticsearch-opentracing
-git+https://github.com/signalfx/python-flask.git@adopt_scope_manager#egg=flask_opentracing
-sfx-jaeger-client>=3.13.1b0.dev1
+git+https://github.com/signalfx/python-django.git@0.1.18post0#egg=django-opentracing
+git+https://github.com/signalfx/python-elasticsearch.git@0.1.4post0#egg=elasticsearch-opentracing
+git+https://github.com/signalfx/python-flask.git@1.0.0post0#egg=flask_opentracing
+sfx-jaeger-client>=3.13.1b0.dev2
 pymongo-opentracing
-git+https://github.com/opentracing-contrib/python-redis.git@v1.0.0#egg=redis-opentracing
+git+https://github.com/signalfx/python-redis.git@v1.0.0post0#egg=redis-opentracing
 requests-opentracing
-tornado_opentracing>=1.0.1
+git+https://github.com/signalfx/python-tornado.git@1.0.1post0#egg=tornado_opentracing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-opentracing>=2.0,<2.1
+opentracing>=2.1,<2.4
 six>=1.12.0
 wrapt

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,21 +13,22 @@ def is_installed(library):
     return library in sys.modules or pkgutil.find_loader(library) is not None
 
 
-jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev1'
+jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev2'
+
 
 # target library to desired instrumentor path/versioned package name
 instrumentors = {
     'celery': 'celery-opentracing',
-    'django': 'https://github.com/signalfx/python-django/tarball/django_2_ot_2_jaeger#egg=django-opentracing',
+    'django': 'https://github.com/signalfx/python-django/tarball/0.1.18post0#egg=django-opentracing',
     'elasticsearch': ('https://github.com/signalfx/python-elasticsearch/tarball/2.0_support_multiple_versions'
                       '#egg=elasticsearch-opentracing'),
-    'flask': 'https://github.com/signalfx/python-flask/tarball/adopt_scope_manager#egg=flask_opentracing',
+    'flask': 'https://github.com/signalfx/python-flask/tarball/1.0.0post0#egg=flask_opentracing',
     'psycopg2': 'dbapi-opentracing>=0.0.4',
     'pymongo': 'pymongo-opentracing',
     'pymysql': 'dbapi-opentracing>=0.0.4',
-    'redis': 'https://github.com/opentracing-contrib/python-redis/tarball/v1.0.0#egg=redis-opentracing',
+    'redis': 'https://github.com/signalfx/python-redis/tarball/v1.0.0post0#egg=redis-opentracing',
     'requests': 'requests-opentracing',
-    'tornado': 'tornado-opentracing==1.0.1'
+    'tornado': 'https://github.com/signalfx/python-tornado/archive/1.0.1post0.zip#egg=tornado_opentracing',
 }
 
 # relevant instrumentors and tracers to uninstall and check for conflicts for target libraries
@@ -70,7 +71,6 @@ def _install_updated_dependency(library, package_path, target=None):
     # explicit upgrade strategy to override potential pip config
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-U',
                            '--upgrade-strategy', 'only-if-needed', package_path] + _to_target_arg(target))
-    _pip_check()
 
 
 def _pip_check():
@@ -125,6 +125,7 @@ def console_script():
 
     install_jaeger(args.target)
     install_deps(args.target)
+    _pip_check()
 
 
 def main():

--- a/signalfx_tracing/libraries/tornado_/README.md
+++ b/signalfx_tracing/libraries/tornado_/README.md
@@ -17,16 +17,17 @@ span tagging:
 | tracer | An instance of an OpenTracing-compatible tracer for all Tornado traces. | `opentracing.tracer` |
 | start_span_cb | A callback invoked upon new span creation.  Must take the Span and request as parameters. | `None` |
 
-OpenTracing 2.0 introduced the [`TornadoScopeManager`](https://github.com/opentracing/opentracing-python/blob/master/opentracing/scope_managers/tornado.py).
+SignalFX's fork of Tornado Opentracing introduced the [`TornadoScopeManager`](https://github.com/signalfx/python-tornado/blob/master/tornado_opentracing/scope_managers.py).
 Due to the asynchronous nature of Tornado, it is strongly recommended that your OpenTracing-compatible tracer use
-this for its scope manager.
+this for its scope manager. Using `TornadoScopeManager` from Tornado Opentracing package ensures that the correct
+scope manager will be used based on the version of Tornado and Python being used.
 
 ```python
 # my_app.py
 from signalfx_tracing import auto_instrument, instrument
 from signalfx_tracing.libraries import tornado_config
 
-from opentracing.scope_managers.tornado import TornadoScopeManager
+from tornado_opentracing.scope_managers import TornadoScopeManager
 
 import tornado.ioloop
 import tornado.web  

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -1,12 +1,10 @@
 # Copyright (C) 2018-2019 SignalFx, Inc. All rights reserved.
 import functools
 import importlib
-import traceback
 import atexit
 import sys
 import os
 
-from opentracing.ext import tags as ext_tags
 from wrapt import decorator, ObjectProxy
 import opentracing
 
@@ -185,15 +183,8 @@ def trace(operation_name=None, tags=None, **kwargs):
 
     @decorator
     def _trace(wrapped, _, _args, _kwargs):
-        with opentracing.tracer.start_active_span(operation_name, tags=tags) as scope:
-            try:
-                return wrapped(*_args, **_kwargs)
-            except Exception:
-                span = scope.span
-                span.set_tag(ext_tags.ERROR, True)
-                span.log_kv({'event': 'error',
-                             'error.object': traceback.format_exc()})
-                raise
+        with opentracing.tracer.start_active_span(operation_name, tags=tags):
+            return wrapped(*_args, **_kwargs)
 
     return _trace(_wrapped)
 

--- a/tests/unit/libraries/tornado_/conftest.py
+++ b/tests/unit/libraries/tornado_/conftest.py
@@ -1,7 +1,16 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
 import pytest
 
+from tornado.testing import AsyncHTTPTestCase as BaseAsyncHTTPTestCase
+
 from signalfx_tracing.libraries.tornado_.instrument import config, uninstrument
+
+
+class AsyncHTTPTestCase(BaseAsyncHTTPTestCase):
+
+    def http_fetch(self, url, *args, **kwargs):
+        self.http_client.fetch(url, self.stop, *args, **kwargs)
+        return self.wait()
 
 
 class TornadoTestSuite(object):

--- a/tests/unit/libraries/tornado_/helpers/__init__.py
+++ b/tests/unit/libraries/tornado_/helpers/__init__.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info >= (3, 3):
+    from ._test_case_gen import AsyncHTTPTestCase  # noqa
+else:
+    from ._test_case import AsyncHTTPTestCase  # noqa

--- a/tests/unit/libraries/tornado_/helpers/_test_case.py
+++ b/tests/unit/libraries/tornado_/helpers/_test_case.py
@@ -1,0 +1,8 @@
+import tornado.testing
+
+
+class AsyncHTTPTestCase(tornado.testing.AsyncHTTPTestCase):
+
+    def http_fetch(self, url, *args, **kwargs):
+        self.http_client.fetch(url, self.stop, *args, **kwargs)
+        return self.wait()

--- a/tests/unit/libraries/tornado_/helpers/_test_case_gen.py
+++ b/tests/unit/libraries/tornado_/helpers/_test_case_gen.py
@@ -1,0 +1,31 @@
+import tornado.testing
+from tornado.httpclient import HTTPError
+from tornado import version_info as tornado_version
+
+from ._test_case import AsyncHTTPTestCase as BaseTestCase
+
+
+use_wait_stop = tornado_version < (5, 0, 0)
+
+if use_wait_stop:
+    def gen_test(func):
+        return func
+else:
+    gen_test = tornado.testing.gen_test
+
+
+class AsyncHTTPTestCase(BaseTestCase):
+
+    @gen_test
+    def _http_fetch_gen(self, url, *args, **kwargs):
+        try:
+            response = yield self.http_client.fetch(url, *args, **kwargs)
+        except HTTPError as exc:
+            response = exc.response
+        return response
+
+    def http_fetch(self, url, *args, **kwargs):
+        fetch = self._http_fetch_gen
+        if use_wait_stop:
+            fetch = super().http_fetch
+        return fetch(url, *args, **kwargs)

--- a/tests/unit/libraries/tornado_/test_tornado.py
+++ b/tests/unit/libraries/tornado_/test_tornado.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2018 SignalFx, Inc. All rights reserved.
-from tornado.testing import AsyncHTTPTestCase
 from opentracing.mocktracer import MockTracer
 from opentracing.ext import tags
 import tornado.web
@@ -8,6 +7,7 @@ import pytest
 import mock
 
 from signalfx_tracing.libraries.tornado_.instrument import config, instrument, uninstrument
+from .helpers import AsyncHTTPTestCase
 from .conftest import TornadoTestSuite
 
 
@@ -66,9 +66,8 @@ class TestTornadoApplicationAndClient(AsyncHTTPTestCase, TornadoTestSuite):
         return tornado.web.Application([('/endpoint', Handler)])
 
     def test_instrument_application_and_client(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
+        response = self.http_fetch(self.get_url('/endpoint'))
 
-        response = self.wait()
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -91,8 +90,7 @@ class TestTornadoApplicationAndClient(AsyncHTTPTestCase, TornadoTestSuite):
                                     'http.status_code': 200}
 
     def test_uninstrument_application_and_client(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -101,8 +99,7 @@ class TestTornadoApplicationAndClient(AsyncHTTPTestCase, TornadoTestSuite):
         self.tracer.reset()
         uninstrument()
 
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
         assert self.tracer.finished_spans() == []
 
@@ -118,9 +115,8 @@ class TestTornadoApplicationAndNotClient(AsyncHTTPTestCase, TornadoTestSuite):
         return self.app
 
     def test_instrument_application_and_client(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
+        response = self.http_fetch(self.get_url('/endpoint'))
 
-        response = self.wait()
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -137,8 +133,7 @@ class TestTornadoApplicationAndNotClient(AsyncHTTPTestCase, TornadoTestSuite):
                                     tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER}
 
     def test_uninstrument_application(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -147,8 +142,7 @@ class TestTornadoApplicationAndNotClient(AsyncHTTPTestCase, TornadoTestSuite):
         self.tracer.reset()
         uninstrument()
 
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
         assert self.tracer.finished_spans() == []
 
@@ -163,9 +157,8 @@ class TestTornadoClientAndNotApplication(AsyncHTTPTestCase, TornadoTestSuite):
         return tornado.web.Application([('/endpoint', Handler)])
 
     def test_instrument_application_and_client(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
+        response = self.http_fetch(self.get_url('/endpoint'))
 
-        response = self.wait()
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -180,8 +173,7 @@ class TestTornadoClientAndNotApplication(AsyncHTTPTestCase, TornadoTestSuite):
                                     'http.status_code': 200}
 
     def test_uninstrument_client(self):
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
 
         spans = self.tracer.finished_spans()
@@ -190,7 +182,6 @@ class TestTornadoClientAndNotApplication(AsyncHTTPTestCase, TornadoTestSuite):
         self.tracer.reset()
         uninstrument()
 
-        self.http_client.fetch(self.get_url('/endpoint'), self.stop)
-        response = self.wait()
+        response = self.http_fetch(self.get_url('/endpoint'))
         assert response.code == 200
         assert self.tracer.finished_spans() == []

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -168,6 +168,7 @@ class TestMethodDecorator(DecoratorTest):
         assert spans[0].tags == {'one': 1, 'two': '2', ext_tags.ERROR: True}
         assert len(spans[0].logs) == 1
         assert spans[0].logs[0].key_values.get('error.object')
+        assert str(spans[0].logs[0].key_values.get('error.object')) == 'SomeException'
 
         assert Thing().traced_method.__name__ == 'traced_method'
 
@@ -181,7 +182,7 @@ class TestMethodDecorator(DecoratorTest):
             def traced_method(cls, *args, **kwargs):
                 assert args == (1,)
                 assert kwargs == dict(one=1)
-                raise CustomException('SomeException')
+                raise CustomException('AnotherException')
 
         with pytest.raises(CustomException):
             Thing().traced_method(1, one=1)
@@ -192,6 +193,7 @@ class TestMethodDecorator(DecoratorTest):
         assert spans[0].tags == {'one': 1, 'two': '2', ext_tags.ERROR: True}
         assert len(spans[0].logs) == 1
         assert spans[0].logs[0].key_values.get('error.object')
+        assert str(spans[0].logs[0].key_values.get('error.object')) == 'AnotherException'
 
         assert Thing().traced_method.__name__ == 'traced_method'
 
@@ -205,7 +207,7 @@ class TestMethodDecorator(DecoratorTest):
             def traced_method(*args, **kwargs):
                 assert args == (1,)
                 assert kwargs == dict(one=1)
-                raise CustomException('SomeException')
+                raise CustomException('YetAnotherException')
 
         with pytest.raises(CustomException):
             Thing.traced_method(1, one=1)
@@ -216,5 +218,6 @@ class TestMethodDecorator(DecoratorTest):
         assert spans[0].tags == {'one': 1, 'two': '2', ext_tags.ERROR: True}
         assert len(spans[0].logs) == 1
         assert spans[0].logs[0].key_values.get('error.object')
+        assert str(spans[0].logs[0].key_values.get('error.object')) == 'YetAnotherException'
 
         assert Thing().traced_method.__name__ == 'traced_method'


### PR DESCRIPTION
Support Tornado6

This commit adds support for Tornado 6. Only change users are expected to make is to import TornadoScopeManager from `tornado_opentracing.scope_managers` instead of `opentracing.scope_managers.tornado`.

This is required as tornado_opentracing automatically exports the correct scope manager to use depending on the version of Python and Tornado being used.