### PR TITLE
Ensure jaeger uninstalled

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -37,7 +37,7 @@ packages = {
     'django': ('django-opentracing',),
     'elasticsearch': ('elasticsearch-opentracing',),
     'flask': ('Flask-OpenTracing',),
-    'jaeger': ('jaeger-client', 'sfx-jaeger-client'),
+    'jaeger': ('sfx-jaeger-client', 'jaeger-client'),
     'psycopg2': ('dbapi-opentracing',),
     'pymongo': ('pymongo-opentracing',),
     'pymysql': ('dbapi-opentracing',),


### PR DESCRIPTION
If there's an existing `sfx-jaeger-client`, the first `jaeger-client` check will initiate a bound to fail uninstallation.  Swapping orders prevents this.