### PR TITLE
Record signalfx version and library tags on local root spans

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ def build(session):
         return
 
     cwd = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(cwd, 'signalfx_tracing/__init__.py')) as init_file:
+    with open(os.path.join(cwd, 'signalfx_tracing/version.py')) as init_file:
         match = re.search("__version__ = ['\"]([^'\"]*)['\"]", init_file.read())
         if not match:
             raise RuntimeError('Not able to determine current version')

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -7,4 +7,4 @@ git+https://github.com/signalfx/python-pymongo.git@v0.0.3post1#egg=pymongo-opent
 git+https://github.com/signalfx/python-redis.git@v1.0.0post1#egg=redis-opentracing
 git+https://github.com/signalfx/python-requests.git@v0.2.0post1#egg=requests-opentracing
 git+https://github.com/signalfx/python-tornado.git@1.0.1post1#egg=tornado_opentracing
-sfx-jaeger-client>=3.13.1b0.dev2
+sfx-jaeger-client>=3.13.1b0.dev3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,4 @@ redis
 requests
 six
 tornado
-sfx-jaeger-client>=3.13.1b0.dev2
+sfx-jaeger-client>=3.13.1b0.dev3

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,7 +13,7 @@ def is_installed(library):
     return library in sys.modules or pkgutil.find_loader(library) is not None
 
 
-jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev2'
+jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev3'
 
 
 # target library to desired instrumentor path/versioned package name

--- a/setup.py
+++ b/setup.py
@@ -108,10 +108,10 @@ with open(os.path.join(cwd, 'README.md')) as readme_file:
     long_description = readme_file.read()
 
 version = None
-with open(os.path.join(cwd, 'signalfx_tracing/__init__.py')) as init_file:
+with open(os.path.join(cwd, 'signalfx_tracing/version.py')) as init_file:
     match = re.search("__version__ = ['\"]([^'\"]*)['\"]", init_file.read())
     if not match:
-        raise RuntimeError('Not able to determine current version in signalfx_tracing/__init__.py')
+        raise RuntimeError('Not able to determine current version in signalfx_tracing/version.py')
     version = match.group(1)
 
 

--- a/signalfx_tracing/__init__.py
+++ b/signalfx_tracing/__init__.py
@@ -2,8 +2,7 @@
 from . import patch_span  # noqa    
 from .instrumentation import instrument, uninstrument, auto_instrument  # noqa
 from .utils import create_tracer, trace  # noqa
-
-__version__ = '1.1.0'
+from .version import __version__  # noqa
 
 # Django
 default_app_config = 'signalfx_tracing.libraries.django_.apps.SignalFxConfig'  # noqa

--- a/signalfx_tracing/tags.py
+++ b/signalfx_tracing/tags.py
@@ -16,3 +16,9 @@ ERROR_MESSAGE = 'sfx.error.message'
 # A stack trace in platform-conventional format; may or may not pertain to
 # an error.
 ERROR_STACK = 'sfx.error.stack'
+
+# SFX_TRACING_VERSION specifies the SignalFx tracing library that generated the span.
+SFX_TRACING_VERSION = 'signalfx.tracing.version'
+
+# SFX_TRACING_LIBRARY specifies the SignalFx tracing library version.
+SFX_TRACING_LIBRARY = 'signalfx.tracing.library'

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -9,6 +9,8 @@ from wrapt import decorator, ObjectProxy
 import opentracing
 
 from .constants import instrumented_attr
+from .tags import SFX_TRACING_LIBRARY, SFX_TRACING_VERSION
+from .version import __version__
 
 
 # Accepted case-insensitive disabling environment variable values
@@ -128,6 +130,11 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     if 'propagation' not in config:
         propagation = _get_env_var('SIGNALFX_PROPAGATION', 'b3')
         config['propagation'] = propagation
+
+    config['root_span_tags'] = {
+        SFX_TRACING_LIBRARY: 'python-tracing',
+        SFX_TRACING_VERSION: __version__
+    }
 
     jaeger_config = Config(config, *args, **kwargs)
 

--- a/signalfx_tracing/version.py
+++ b/signalfx_tracing/version.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2020 SignalFx. All rights reserved.
+
+__version__ = '1.2.0'


### PR DESCRIPTION
Requires signalfx/jaeger-client-python v3.13.1b0.dev3
(https://github.com/signalfx/jaeger-client-python/pull/3)