### PR TITLE
Updated how logging is handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ deploying in a test environment.
     to be called from another traced function or auto-instrumented request handler, 
     its resulting span would be parented by that caller function's span.
 
+## Tracer debug logging
+
+The tracer can be configured to log debugging information by setting `SIGNALFX_TRACING_DEBUG` to `true`. This tell the tracer to log additional information that might be
+helpful in understanding how it operates. Note that in order for debug logging to work, you application must initialize logging with `logging.basicConfig()` first.
+
 ## Inject trace IDs in logs
 
 Link individual log entries with trace IDs and span IDs associated with corresponding events. The SignalFx Python instrumentation patches `logging.Logger.makeRecord` method to automatically inject trace context into all `LogRecord` objects. When `SIGNALFX_LOGS_INJECTION` environment variable is set to `true`, the logging instrumentation also sets a custom logging format to automatically inject the trace context into logs. The default format looks like the following:

--- a/requirements-inst.txt
+++ b/requirements-inst.txt
@@ -7,4 +7,4 @@ git+https://github.com/signalfx/python-pymongo.git@v0.0.3post1#egg=pymongo-opent
 git+https://github.com/signalfx/python-redis.git@v1.0.0post1#egg=redis-opentracing
 git+https://github.com/signalfx/python-requests.git@v0.2.0post1#egg=requests-opentracing
 git+https://github.com/signalfx/python-tornado.git@1.0.1post1#egg=tornado_opentracing
-sfx-jaeger-client>=3.13.1b0.dev3
+sfx-jaeger-client>=3.13.1b0.dev4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,4 @@ redis
 requests
 six
 tornado
-sfx-jaeger-client>=3.13.1b0.dev3
+sfx-jaeger-client>=3.13.1b0.dev4

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,7 +13,7 @@ def is_installed(library):
     return library in sys.modules or pkgutil.find_loader(library) is not None
 
 
-jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev3'
+jaeger_client = 'sfx-jaeger-client>=3.13.1b0.dev4'
 
 
 # target library to desired instrumentor path/versioned package name

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018-2019 SignalFx. All rights reserved.
+import logging
 import functools
 import importlib
 import atexit
@@ -130,6 +131,13 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     if 'propagation' not in config:
         propagation = _get_env_var('SIGNALFX_PROPAGATION', 'b3')
         config['propagation'] = propagation
+
+    logger = logging.getLogger('signalfx-tracing')
+    config['logging'] = True
+    config['logger'] = logger
+
+    if _get_env_var('SIGNALFX_TRACING_DEBUG', False):
+        logger.setLevel(logging.DEBUG)
 
     config['root_span_tags'] = {
         SFX_TRACING_LIBRARY: 'python-tracing',


### PR DESCRIPTION
- Tracer now always enables logging.
- Logging level is set to DEBUG when SIGNALFX_TRACING_DEBUG is set to
True.
- If SIGNALFX_LOGS_INJECTION is also set to True, the default logging
format is set automatically as well.