### PR TITLE
Add support for SIGNALFX_RECORDED_VALUE_MAX_LENGTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ If you don't provide a  `config` dictionary or don't specify the following items
 for your tracer, these environment variables are checked before selecting a
 default value:
 
-| Config kwarg | environment variable | default value |
-|--------------|----------------------|---------------|
-| `service_name` | `SIGNALFX_SERVICE_NAME` | `'SignalFx-Tracing'` |
-| `jaeger_endpoint` | `SIGNALFX_ENDPOINT_URL` | `'http://localhost:9080/v1/trace'` |
-| `jaeger_password` | `SIGNALFX_ACCESS_TOKEN` | `None` |
+| Config kwarg | environment variable | default value | notes |
+|--------------|----------------------|---------------| |
+| `service_name` | `SIGNALFX_SERVICE_NAME` | `'SignalFx-Tracing'` | The name to identify the service in SignalFx. |
+| `jaeger_endpoint` | `SIGNALFX_ENDPOINT_URL` | `'http://localhost:9080/v1/trace'` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
+| `jaeger_password` | `SIGNALFX_ACCESS_TOKEN` | `None` | The SignalFx organization access token. |
+| `N/A` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | Maximum length an attribute value can have. Values longer than this are truncated. |
 
 ## Automatically instrument a Python application
 

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -11,6 +11,8 @@ auto_instrumentable_libraries = (
     'tornado', 'logging'
 )
 
+default_max_tag_value_length = 1200
+
 logging_format = (
     '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
     '[signalfx.trace_id=%(sfxTraceId)s signalfx.span_id=%(sfxSpanId)s] '

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -9,7 +9,7 @@ import os
 from wrapt import decorator, ObjectProxy
 import opentracing
 
-from .constants import instrumented_attr
+from .constants import default_max_tag_value_length, instrumented_attr
 from .tags import SFX_TRACING_LIBRARY, SFX_TRACING_VERSION
 from .version import __version__
 
@@ -143,6 +143,11 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
         SFX_TRACING_LIBRARY: 'python-tracing',
         SFX_TRACING_VERSION: __version__
     }
+
+    config['max_tag_value_length'] = int(_get_env_var(
+        'SIGNALFX_RECORDED_VALUE_MAX_LENGTH',
+        default_max_tag_value_length,
+    ))
 
     jaeger_config = Config(config, *args, **kwargs)
 


### PR DESCRIPTION
SIGNALFX_RECORDED_VALUE_MAX_LENGTH env var allows to set the max size of
attribute values. Any values larger than specified size will be
truncated. Defaults to 1200.