### PR TITLE
Inject service name and environment to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ default value:
 | Config kwarg | environment variable | default value | notes |
 |--------------|----------------------|---------------|-------|
 | `service_name` | `SIGNALFX_SERVICE_NAME` | `'SignalFx-Tracing'` | The name to identify the service in SignalFx. |
-| `service_environment` | `SIGNALFX_SERVICE_ENVIRONMENT` | `'unknown'` | The service's environment name - attached to a span's Process tags (`signalfx.environment`)
+| `service_environment` | `SIGNALFX_ENV` | `'unknown'` | The service's environment name - attached to a span's Process tags (`signalfx.environment`)
 and when log injection is enabled, is added to log messages.
 | `jaeger_endpoint` | `SIGNALFX_ENDPOINT_URL` | `'http://localhost:9080/v1/trace'` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
 | `jaeger_password` | `SIGNALFX_ACCESS_TOKEN` | `None` | The SignalFx organization access token. |
@@ -118,7 +118,7 @@ corresponding `instrument()` [keyword argument](#Supported-Frameworks-and-Librar
     ```bash
     # Specify a name and environment for the service in SignalFx.
     $ export SIGNALFX_SERVICE_NAME="your_service"
-    $ export SIGNALFX_SERVICE_ENVIRONMENT="prod"
+    $ export SIGNALFX_ENV="prod"
     # Set the endpoint URL for the Smart Agent, OpenTelemetry Collector, or ingest endpoint.
     $ export SIGNALFX_ENDPOINT_URL="http://localhost:9080/v1/trace"
     # If you're reporting directly to SignalFx without a Smart Agent or Collector, provide the access token for your SignalFx organization.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ default value:
 | Config kwarg | environment variable | default value | notes |
 |--------------|----------------------|---------------|-------|
 | `service_name` | `SIGNALFX_SERVICE_NAME` | `'SignalFx-Tracing'` | The name to identify the service in SignalFx. |
+| `service_environment` | `SIGNALFX_SERVICE_ENVIRONMENT` | `'unknown'` | The service's environment name - attached to a span's Process tags (`signalfx.environment`)
+and when log injection is enabled, is added to log messages.
 | `jaeger_endpoint` | `SIGNALFX_ENDPOINT_URL` | `'http://localhost:9080/v1/trace'` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
 | `jaeger_password` | `SIGNALFX_ACCESS_TOKEN` | `None` | The SignalFx organization access token. |
 | `N/A` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum length an attribute value can have. Values longer than this are truncated. |
@@ -114,8 +116,9 @@ corresponding `instrument()` [keyword argument](#Supported-Frameworks-and-Librar
 
 1. Set the service name, endpoint URL, and access token:
     ```bash
-    # Specify a name for the service in SignalFx.
+    # Specify a name and environment for the service in SignalFx.
     $ export SIGNALFX_SERVICE_NAME="your_service"
+    $ export SIGNALFX_SERVICE_ENVIRONMENT="prod"
     # Set the endpoint URL for the Smart Agent, OpenTelemetry Collector, or ingest endpoint.
     $ export SIGNALFX_ENDPOINT_URL="http://localhost:9080/v1/trace"
     # If you're reporting directly to SignalFx without a Smart Agent or Collector, provide the access token for your SignalFx organization.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ default value:
 | Config kwarg | environment variable | default value | notes |
 |--------------|----------------------|---------------|-------|
 | `service_name` | `SIGNALFX_SERVICE_NAME` | `'SignalFx-Tracing'` | The name to identify the service in SignalFx. |
-| `service_environment` | `SIGNALFX_ENV` | `'unknown'` | The service's environment name - attached to a span's Process tags (`signalfx.environment`)
+| `service_environment` | `SIGNALFX_ENV` | `''` | The service's environment name - attached to a span's Process tags (`signalfx.environment`)
 and when log injection is enabled, is added to log messages.
 | `jaeger_endpoint` | `SIGNALFX_ENDPOINT_URL` | `'http://localhost:9080/v1/trace'` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
 | `jaeger_password` | `SIGNALFX_ACCESS_TOKEN` | `None` | The SignalFx organization access token. |

--- a/noxfile.py
+++ b/noxfile.py
@@ -340,6 +340,7 @@ def _tornado_via_extras(session, tornado):
     session.run('pytest', 'tests/unit/libraries/tornado_')
     session.run('pytest', 'tests/integration/tornado_')
 
+
 @nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
 def logging(session):
     install_unit_tests(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -339,3 +339,11 @@ def _tornado_via_extras(session, tornado):
     session.install(f'{sdist}[tornado]')
     session.run('pytest', 'tests/unit/libraries/tornado_')
     session.run('pytest', 'tests/integration/tornado_')
+
+@nox.session(python=('2.7', '3.4', '3.5', '3.6', '3.7'), reuse_venv=True)
+def logging(session):
+    install_unit_tests(session)
+    session.run('sfx-py-trace-bootstrap')
+    pip_check(session)
+    pip_freeze(session)
+    session.run('pytest', 'tests/unit/libraries/logging_')

--- a/noxfile.py
+++ b/noxfile.py
@@ -345,6 +345,4 @@ def _tornado_via_extras(session, tornado):
 def logging(session):
     install_unit_tests(session)
     session.run('sfx-py-trace-bootstrap')
-    pip_check(session)
-    pip_freeze(session)
     session.run('pytest', 'tests/unit/libraries/logging_')

--- a/signalfx_tracing/constants.py
+++ b/signalfx_tracing/constants.py
@@ -15,6 +15,7 @@ default_max_tag_value_length = 1200
 
 logging_format = (
     '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
-    '[signalfx.trace_id=%(sfxTraceId)s signalfx.span_id=%(sfxSpanId)s] '
+    '[signalfx.trace_id=%(sfxTraceId)s signalfx.span_id=%(sfxSpanId)s'
+    ' signalfx.service=%(sfxService)s signalfx.environment=%(sfxEnvironment)s] '
     '- %(message)s'
 )

--- a/signalfx_tracing/libraries/logging_/instrument.py
+++ b/signalfx_tracing/libraries/logging_/instrument.py
@@ -12,34 +12,37 @@ config = utils.Config(
     logging_format=os.environ.get('SIGNALFX_LOGGING_FORMAT', logging_format)
 )
 
+
 def padded_hex(num):
     return '{:016x}'.format(num)
 
+
 def makeRecordPatched(tracer):
-  def patched(makeRecord, instance, args, kwargs):
-      rv = makeRecord(*args, **kwargs)
+    def patched(makeRecord, instance, args, kwargs):
+        rv = makeRecord(*args, **kwargs)
 
-      fields = {
-        'sfxTraceId': '',
-        'sfxSpanId': '',
-        'sfxService': '',
-        'sfxEnvironment': ''
-      }
+        fields = {
+          'sfxTraceId': '',
+          'sfxSpanId': '',
+          'sfxService': '',
+          'sfxEnvironment': ''
+        }
 
-      span = tracer.active_span
+        span = tracer.active_span
 
-      if span is not None:
-          fields['sfxTraceId'] = padded_hex(span.trace_id)
-          fields['sfxSpanId'] = padded_hex(span.span_id)
-          fields['sfxService'] = tracer.service_name
-          fields['sfxEnvironment'] = tracer.tags.get(tags.SFX_ENVIRONMENT, 'unknown')
+        if span is not None:
+            fields['sfxTraceId'] = padded_hex(span.trace_id)
+            fields['sfxSpanId'] = padded_hex(span.span_id)
+            fields['sfxService'] = tracer.service_name
+            fields['sfxEnvironment'] = tracer.tags.get(tags.SFX_ENVIRONMENT, 'unknown')
 
-      for field in fields:
-        setattr(rv, field, fields[field])
+        for field in fields:
+            setattr(rv, field, fields[field])
 
-      return rv
+        return rv
 
-  return patched
+    return patched
+
 
 def instrument(tracer=None):
     """
@@ -51,7 +54,7 @@ def instrument(tracer=None):
 
     if utils.is_instrumented(logging):
         return
-  
+
     if not config.injection_enabled:
         return
 

--- a/signalfx_tracing/libraries/logging_/instrument.py
+++ b/signalfx_tracing/libraries/logging_/instrument.py
@@ -34,7 +34,7 @@ def makeRecordPatched(tracer):
             fields['sfxTraceId'] = padded_hex(span.trace_id)
             fields['sfxSpanId'] = padded_hex(span.span_id)
             fields['sfxService'] = tracer.service_name
-            fields['sfxEnvironment'] = tracer.tags.get(tags.SFX_ENVIRONMENT, 'unknown')
+            fields['sfxEnvironment'] = tracer.tags.get(tags.SFX_ENVIRONMENT, '')
 
         for field in fields:
             setattr(rv, field, fields[field])

--- a/signalfx_tracing/libraries/logging_/instrument.py
+++ b/signalfx_tracing/libraries/logging_/instrument.py
@@ -4,32 +4,42 @@ import os
 from wrapt import wrap_function_wrapper
 import opentracing
 
-from signalfx_tracing import utils
+from signalfx_tracing import utils, tags
 from signalfx_tracing.constants import logging_format
-
 
 config = utils.Config(
     injection_enabled=utils.is_truthy(os.environ.get('SIGNALFX_LOGS_INJECTION', False)),
     logging_format=os.environ.get('SIGNALFX_LOGGING_FORMAT', logging_format)
 )
 
-
 def padded_hex(num):
     return '{:016x}'.format(num)
 
+def makeRecordPatched(tracer):
+  def patched(makeRecord, instance, args, kwargs):
+      rv = makeRecord(*args, **kwargs)
 
-def makeRecordPatched(makeRecord, instance, args, kwargs):
-    rv = makeRecord(*args, **kwargs)
-    span_id = ''
-    trace_id = ''
-    span = opentracing.tracer.active_span
-    if span is not None:
-        span_id = padded_hex(span.span_id)
-        trace_id = padded_hex(span.trace_id)
-    setattr(rv, 'sfxTraceId', span_id)
-    setattr(rv, 'sfxSpanId', trace_id)
-    return rv
+      fields = {
+        'sfxTraceId': '',
+        'sfxSpanId': '',
+        'sfxService': '',
+        'sfxEnvironment': ''
+      }
 
+      span = tracer.active_span
+
+      if span is not None:
+          fields['sfxTraceId'] = padded_hex(span.trace_id)
+          fields['sfxSpanId'] = padded_hex(span.span_id)
+          fields['sfxService'] = tracer.service_name
+          fields['sfxEnvironment'] = tracer.tags.get(tags.SFX_ENVIRONMENT, 'unknown')
+
+      for field in fields:
+        setattr(rv, field, fields[field])
+
+      return rv
+
+  return patched
 
 def instrument(tracer=None):
     """
@@ -38,16 +48,21 @@ def instrument(tracer=None):
     inject trace context into logs.
     """
     logging = utils.get_module('logging')
+
     if utils.is_instrumented(logging):
         return
+  
+    if not config.injection_enabled:
+        return
 
-    wrap_function_wrapper(logging, 'Logger.makeRecord', makeRecordPatched)
+    tracer = tracer or opentracing.tracer
+    wrap_function_wrapper(logging, 'Logger.makeRecord', makeRecordPatched(tracer))
+    level = logging.INFO
 
-    if config.injection_enabled:
-        level = logging.INFO
-        if utils.is_truthy(os.environ.get('SIGNALFX_TRACING_DEBUG', False)):
-            level = logging.DEBUG
-        logging.basicConfig(level=level, format=config.logging_format)
+    if utils.is_truthy(os.environ.get('SIGNALFX_TRACING_DEBUG', False)):
+        level = logging.DEBUG
+
+    logging.basicConfig(level=level, format=config.logging_format)
 
     utils.mark_instrumented(logging)
 

--- a/signalfx_tracing/tags.py
+++ b/signalfx_tracing/tags.py
@@ -22,3 +22,5 @@ SFX_TRACING_VERSION = 'signalfx.tracing.version'
 
 # SFX_TRACING_LIBRARY specifies the SignalFx tracing library version.
 SFX_TRACING_LIBRARY = 'signalfx.tracing.library'
+
+SFX_ENVIRONMENT = 'signalfx.environment'

--- a/signalfx_tracing/tags.py
+++ b/signalfx_tracing/tags.py
@@ -23,4 +23,4 @@ SFX_TRACING_VERSION = 'signalfx.tracing.version'
 # SFX_TRACING_LIBRARY specifies the SignalFx tracing library version.
 SFX_TRACING_LIBRARY = 'signalfx.tracing.library'
 
-SFX_ENVIRONMENT = 'signalfx.environment'
+SFX_ENVIRONMENT = 'environment'

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -145,7 +145,7 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     }
 
     tags = config.get('tags', {})
-    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_ENV', config.get('service_environment', 'unknown'))
+    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_ENV', config.get('service_environment', ''))
     config['tags'] = tags
 
     config['max_tag_value_length'] = int(_get_env_var(

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -145,7 +145,7 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     }
 
     tags = config.get('tags', {})
-    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_SERVICE_ENVIRONMENT', config.get('service_environment', 'unknown'))
+    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_ENV', config.get('service_environment', 'unknown'))
     config['tags'] = tags
 
     config['max_tag_value_length'] = int(_get_env_var(

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -10,7 +10,7 @@ from wrapt import decorator, ObjectProxy
 import opentracing
 
 from .constants import default_max_tag_value_length, instrumented_attr
-from .tags import SFX_TRACING_LIBRARY, SFX_TRACING_VERSION
+from .tags import SFX_ENVIRONMENT, SFX_TRACING_LIBRARY, SFX_TRACING_VERSION
 from .version import __version__
 
 
@@ -143,6 +143,10 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
         SFX_TRACING_LIBRARY: 'python-tracing',
         SFX_TRACING_VERSION: __version__
     }
+
+    tags = config.get('tags', {})
+    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_SERVICE_ENVIRONMENT', config.get('service_environment', 'unknown'))
+    config['tags'] = tags
 
     config['max_tag_value_length'] = int(_get_env_var(
         'SIGNALFX_RECORDED_VALUE_MAX_LENGTH',

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -145,7 +145,7 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     }
 
     tags = config.get('tags', {})
-    tags[SFX_ENVIRONMENT] = _get_env_var('SIGNALFX_ENV', config.get('service_environment', ''))
+    tags[SFX_ENVIRONMENT] = config.get('service_environment', _get_env_var('SIGNALFX_ENV', ''))
     config['tags'] = tags
 
     config['max_tag_value_length'] = int(_get_env_var(

--- a/signalfx_tracing/utils.py
+++ b/signalfx_tracing/utils.py
@@ -145,7 +145,7 @@ def create_tracer(access_token=None, set_global=True, config=None, *args, **kwar
     }
 
     tags = config.get('tags', {})
-    tags[SFX_ENVIRONMENT] = config.get('service_environment', _get_env_var('SIGNALFX_ENV', ''))
+    tags[SFX_ENVIRONMENT] = tags.get(SFX_ENVIRONMENT, _get_env_var('SIGNALFX_ENV', ''))
     config['tags'] = tags
 
     config['max_tag_value_length'] = int(_get_env_var(

--- a/tests/unit/libraries/logging_/test_logging.py
+++ b/tests/unit/libraries/logging_/test_logging.py
@@ -4,7 +4,7 @@ import sys
 import opentracing
 import logging
 
-from signalfx_tracing import create_tracer, tags
+from signalfx_tracing import create_tracer
 from signalfx_tracing.utils import trace
 from signalfx_tracing.libraries.logging_.instrument import instrument, config
 
@@ -51,7 +51,7 @@ class TestLogging(LoggingTestSuite):
     def test_injection(self, caplog):
         config.injection_enabled = True
         self.setup_tracing(caplog)
-     
+
         @trace
         def traced_function(*args, **kwargs):
             assert args == (1,)

--- a/tests/unit/libraries/logging_/test_logging.py
+++ b/tests/unit/libraries/logging_/test_logging.py
@@ -6,6 +6,7 @@ import logging
 
 from signalfx_tracing import create_tracer
 from signalfx_tracing.utils import trace
+from signalfx_tracing.tags import SFX_ENVIRONMENT
 from signalfx_tracing.libraries.logging_.instrument import instrument, config
 
 from .conftest import LoggingTestSuite
@@ -19,7 +20,8 @@ else:
 class TestLogging(LoggingTestSuite):
 
     def setup_tracing(self, caplog):
-        self.tracer = create_tracer(config={'service_name': 'loginject', 'service_environment': 'test'})
+        tags = {SFX_ENVIRONMENT: 'test'}
+        self.tracer = create_tracer(config={'service_name': 'loginject', 'tags': tags})
         instrument(self.tracer)
         opentracing.tracer = self.tracer
         caplog.set_level(logging.INFO)


### PR DESCRIPTION
This PR adds a new env var `SIGNALFX_SERVICE_ENVIRONMENT` (or config option `service_environment`, default: `unknown`). Spans now have the environment in the `Process` field tags (so once per span batch).

If log injection is enabled, the log records have new variables available:
* `sfxService` - corresponds to the service name option's value
* `sfxService` - value of service environment option

The default logging format was changed to include these variables. For backwards compatibility  I did not remove the `signalfx.` prefix from log variables, although I guess a better option would be `[signalfx trace_id=... span_id=... service=xyz environment=foo]`

Miscellaneous:
- Fix logging tests (they were failing previously)
- Add logging tests to nox